### PR TITLE
Fix NsSideeffect link routing

### DIFF
--- a/src/components/NsSideeffect.vue
+++ b/src/components/NsSideeffect.vue
@@ -1,6 +1,6 @@
 <template>
   <template v-if="showButton">
-    <ion-button expand="full" color="light" :routerLink="link">
+    <ion-button expand="full" color="light" :routerLink="resolvedLink">
       <ion-icon slot="start" :icon="arrowForwardOutline"></ion-icon>
       <slot></slot>
     </ion-button>
@@ -25,7 +25,19 @@ const props = defineProps<{
 }>()
 
 const icon = computed(() => !props.severe ? (!props.todo ? undefined : arrowForwardOutline) : caretForward)
-const showButton = computed(() => !!props.link)
+const resolvedLink = computed(() => {
+  if (!props.link) {
+    return undefined
+  }
+
+  if (props.link.startsWith('/tabs/med/')) {
+    return props.link.replace('/tabs/med/', '/tabs/meds/')
+  }
+
+  return props.link
+})
+
+const showButton = computed(() => !!resolvedLink.value)
 
 </script>
 


### PR DESCRIPTION
## Summary
- normalize medication links in NsSideeffect to point to the meds route
- only render the link button when a resolved link exists

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d2566d742c832eb730b2713bfbf73e