### PR TITLE
feat: add NsButtonGroup component

### DIFF
--- a/src/components/NsButtonGroup.vue
+++ b/src/components/NsButtonGroup.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="ns-button-group">
+    <ion-button
+      v-for="option in options"
+      :key="option.value"
+      :fill="isActive(option) ? 'solid' : 'outline'"
+      expand="block"
+      @click="onSelect(option.value)"
+    >
+      {{ option.label }}
+    </ion-button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { IonButton } from '@ionic/vue'
+
+type ButtonValue = string | number
+
+type ButtonOption = {
+  label: string
+  value: ButtonValue
+}
+
+const props = defineProps<{
+  options: ButtonOption[]
+  modelValue?: ButtonValue
+}>()
+
+const emit = defineEmits<{
+  (event: 'update:modelValue', value: ButtonValue): void
+}>()
+
+const isActive = (option: ButtonOption) => option.value === props.modelValue
+
+const onSelect = (value: ButtonValue) => {
+  if (value !== props.modelValue) {
+    emit('update:modelValue', value)
+  }
+}
+</script>
+
+<style scoped>
+.ns-button-group {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+  gap: 0.5rem;
+  width: 100%;
+}
+
+.ns-button-group ion-button {
+  width: 100%;
+  margin: 0;
+}
+</style>


### PR DESCRIPTION
## Summary
- add a reusable NsButtonGroup component to render ion-buttons as a radio-like selector
- highlight the active option with a solid fill while inactive buttons remain outlined
- ensure the button group fills the available width and wraps to additional rows when space is limited

## Testing
- npm run lint *(fails due to pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d266eb0f94832e868d6d6a93264eae