### PR TITLE
Fix NsHabitusInput initial selection

### DIFF
--- a/src/components/NsHabitusInput.vue
+++ b/src/components/NsHabitusInput.vue
@@ -3,22 +3,22 @@
     fill="outline" interface="popover" v-model="currentMulti">
 
     <template v-if="mode == 'child'">
-      <ion-select-option :value="0.85">Sehr dünn</ion-select-option>
-      <ion-select-option :value="0.92">Dünn</ion-select-option>
-      <ion-select-option :value="1.00">Normaler Habitus</ion-select-option>
-      <ion-select-option :value="1.10">Leicht übergewichtig</ion-select-option>
-      <ion-select-option :value="1.20">Übergewichtig</ion-select-option>
-      <ion-select-option :value="1.30">Sehr übergewichtig</ion-select-option>
+      <ion-select-option :value="formatOptionValue(0.85)">Sehr dünn</ion-select-option>
+      <ion-select-option :value="formatOptionValue(0.92)">Dünn</ion-select-option>
+      <ion-select-option :value="formatOptionValue(1.00)">Normaler Habitus</ion-select-option>
+      <ion-select-option :value="formatOptionValue(1.10)">Leicht übergewichtig</ion-select-option>
+      <ion-select-option :value="formatOptionValue(1.20)">Übergewichtig</ion-select-option>
+      <ion-select-option :value="formatOptionValue(1.30)">Sehr übergewichtig</ion-select-option>
     </template>
 
     <template v-else-if="mode == 'adult'">
-      <ion-select-option :value="0.84">Sehr dünn</ion-select-option>
-      <ion-select-option :value="0.91">Dünn</ion-select-option>
-      <ion-select-option :value="1.05">Normaler Habitus</ion-select-option>
-      <ion-select-option :value="1.23">Sportlich/Muskulös</ion-select-option>
-      <ion-select-option :value="1.27">Leicht übergewichtig</ion-select-option>
-      <ion-select-option :value="1.45">Übergewichtig</ion-select-option>
-      <ion-select-option :value="1.68">Sehr übergewichtig</ion-select-option>
+      <ion-select-option :value="formatOptionValue(0.84)">Sehr dünn</ion-select-option>
+      <ion-select-option :value="formatOptionValue(0.91)">Dünn</ion-select-option>
+      <ion-select-option :value="formatOptionValue(1.05)">Normaler Habitus</ion-select-option>
+      <ion-select-option :value="formatOptionValue(1.23)">Sportlich/Muskulös</ion-select-option>
+      <ion-select-option :value="formatOptionValue(1.27)">Leicht übergewichtig</ion-select-option>
+      <ion-select-option :value="formatOptionValue(1.45)">Übergewichtig</ion-select-option>
+      <ion-select-option :value="formatOptionValue(1.68)">Sehr übergewichtig</ion-select-option>
     </template>
 
   </ion-select>
@@ -38,10 +38,21 @@ const emit = defineEmits<{
   (event: 'update:modelValue', value: number): void
 }>()
 
-const currentMulti = ref(props.modelValue)
-watch(() => currentMulti.value, (v) => {
-  if (currentMulti.value !== props.modelValue) {
-    emit('update:modelValue', currentMulti.value)
+const formatOptionValue = (value: number) => value.toFixed(2)
+
+const currentMulti = ref(formatOptionValue(props.modelValue))
+
+watch(() => props.modelValue, (value) => {
+  const formatted = formatOptionValue(value)
+  if (currentMulti.value !== formatted) {
+    currentMulti.value = formatted
+  }
+})
+
+watch(() => currentMulti.value, (value) => {
+  const numericValue = Number.parseFloat(value)
+  if (!Number.isNaN(numericValue) && numericValue !== props.modelValue) {
+    emit('update:modelValue', numericValue)
   }
 })
 


### PR DESCRIPTION
## Summary
- normalize NsHabitusInput option values to strings so the select can match its initial modelValue
- keep the internal select state synchronized with the numeric model by formatting incoming props and emitting parsed numbers

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d66b72e988832ea11777348d16d2e5