### PR TITLE
Refactor habitus selection to use named modes

### DIFF
--- a/src/types/emergency.ts
+++ b/src/types/emergency.ts
@@ -4,6 +4,14 @@ export type WeightAccuracyValue = 'direct' | 'estimate'
 export type WeightEstimateByValue = 'by-age' | 'by-height'
 export type SexValue = 'male' | 'female'
 export type HabitusModeValue = 'child' | 'adult'
+export type HabitusValue =
+  | 'very-thin'
+  | 'thin'
+  | 'normal'
+  | 'sporty'
+  | 'lightly-overweight'
+  | 'overweight'
+  | 'very-overweight'
 export type WeightError = 'invalid_weight' | 'invalid_age' | 'invalid_height' | 'undefined'
 
 export class Patient {
@@ -14,9 +22,32 @@ export class Patient {
   public Sex: SexValue
   public Age: number
   public Height: number
-  public HabitusMultiplier: number
+  public Habitus: HabitusValue
 
   public Weight: number
+
+  private static readonly DEFAULT_HABITUS: HabitusValue = 'normal'
+
+  private static readonly HABITUS_MULTIPLIERS: Record<HabitusModeValue, Record<HabitusValue, number>> = {
+    child: {
+      'very-thin': 0.85,
+      thin: 0.92,
+      normal: 1.00,
+      sporty: 1.10,
+      'lightly-overweight': 1.10,
+      overweight: 1.20,
+      'very-overweight': 1.30,
+    },
+    adult: {
+      'very-thin': 0.84,
+      thin: 0.91,
+      normal: 1.05,
+      sporty: 1.23,
+      'lightly-overweight': 1.27,
+      overweight: 1.45,
+      'very-overweight': 1.68,
+    },
+  }
 
   // ######################################################
 
@@ -28,7 +59,7 @@ export class Patient {
     this.Sex = 'male'
     this.Age = 50
     this.Height = 180
-    this.HabitusMultiplier = 1
+    this.Habitus = Patient.DEFAULT_HABITUS
 
     this.Weight = 80
   }
@@ -44,6 +75,14 @@ export class Patient {
       )
     ) { return 'child' }
     else { return 'adult' }
+  }
+
+  // ######################################################
+
+  get currentHabitusMulti(): number {
+    const mode = this.currentHabitusMode
+    const modeMultipliers = Patient.HABITUS_MULTIPLIERS[mode]
+    return modeMultipliers[this.Habitus] ?? modeMultipliers[Patient.DEFAULT_HABITUS]
   }
 
   // ######################################################
@@ -80,7 +119,7 @@ export class Patient {
         {
 
           return CurveCalculation.calculateChildWeightByAge(
-            this.Sex, this.Age, this.HabitusMultiplier
+            this.Sex, this.Age, this.currentHabitusMulti
           )
 
         }
@@ -104,7 +143,7 @@ export class Patient {
           {
 
             return CurveCalculation.calculateChildWeightByHeight(
-              this.Sex, this.Height, this.HabitusMultiplier
+              this.Sex, this.Height, this.currentHabitusMulti
             )
 
           }
@@ -114,7 +153,7 @@ export class Patient {
           {
 
             return BmiCalculation.calculateAdultWeightByHeight(
-              this.Sex, this.Height, this.HabitusMultiplier
+              this.Sex, this.Height, this.currentHabitusMulti
             )
 
           }

--- a/src/views/content/emergency/NsPatientInfo.vue
+++ b/src/views/content/emergency/NsPatientInfo.vue
@@ -24,7 +24,8 @@ const info = computed(() => {
   xx.push(`Age: ${props.patient.Age}`)
   xx.push(`Weight: ${props.patient.Weight}`)
   xx.push(`Height: ${props.patient.Height}`)
-  xx.push(`Habitus: ${props.patient.HabitusMultiplier}`)
+  xx.push(`Habitus: ${props.patient.Habitus}`)
+  xx.push(`HabitusMultiplier: ${props.patient.currentHabitusMulti}`)
   xx.push(`calcHabitusMode: ${props.patient.currentHabitusMode}`)
   xx.push(`calcWeight: ${props.patient.currentWeight}`)
 

--- a/src/views/content/emergency/NsPatientInput.vue
+++ b/src/views/content/emergency/NsPatientInput.vue
@@ -30,7 +30,7 @@
         </template>
 
         <ns-sex-input v-model="patientSex"></ns-sex-input>
-        <ns-habitus-input v-model="patientHabitusMulti" :mode="modelValue.currentHabitusMode"></ns-habitus-input>
+        <ns-habitus-input v-model="patientHabitus" :mode="modelValue.currentHabitusMode"></ns-habitus-input>
 
       </div>
 
@@ -52,7 +52,7 @@ import NsSexInput from '@/components/NsSexInput.vue';
 import NsHabitusInput from '@/components/NsHabitusInput.vue';
 
 import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
-import { Patient, SexValue, WeightAccuracyValue, WeightEstimateByValue } from '@/types/emergency';
+import { HabitusValue, Patient, SexValue, WeightAccuracyValue, WeightEstimateByValue } from '@/types/emergency';
 import { gainFocus } from '@/service/input';
 
 const props = defineProps<{
@@ -70,7 +70,7 @@ const patientSex = ref<SexValue>(props.modelValue.Sex)
 const patientAge = ref<number>(props.modelValue.Age)
 const patientWeight = ref<number>(props.modelValue.Weight)
 const patientHeight = ref<number>(props.modelValue.Height)
-const patientHabitusMulti = ref<number>(props.modelValue.HabitusMultiplier)
+const patientHabitus = ref<HabitusValue>(props.modelValue.Habitus)
 
 const inputWeight = ref<any|null>(null)
 const inputAge = ref<any|null>(null)
@@ -120,7 +120,7 @@ watch(() => [
   patientAge.value,
   patientWeight.value,
   patientHeight.value,
-  patientHabitusMulti.value
+  patientHabitus.value
 ], () => {
   const newPatient = new Patient()
   newPatient.WeightAccuracy = weightAccuracy.value
@@ -129,7 +129,7 @@ watch(() => [
   newPatient.Sex = patientSex.value
   newPatient.Weight = patientWeight.value
   newPatient.Height = patientHeight.value
-  newPatient.HabitusMultiplier = patientHabitusMulti.value
+  newPatient.Habitus = patientHabitus.value
   emit('update:modelValue', newPatient)
 })
 


### PR DESCRIPTION
## Summary
- store habitus selections as descriptive string values and expose a derived multiplier on the patient model
- update NsHabitusInput to offer string option values for child and adult modes
- align patient input and info components with the renamed habitus property

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d66f2fc590832e904ba3b845ea4ef7