### PR TITLE
Add library scaffolding and routes

### DIFF
--- a/src/data/library.ts
+++ b/src/data/library.ts
@@ -1,0 +1,5 @@
+import { LibraryListItem } from '@/types/library-list';
+
+export const libraryItems: LibraryListItem[] = [
+  // Entries and sublists will be added here.
+];

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -24,7 +24,25 @@ const routes: Array<RouteRecordRaw> = [
         component: () => import('@/views/content/medications/MedsContentPage.vue'),
         props: true
       },
-
+      {
+        path: 'lib',
+        component: () => import('@/views/content/LibraryListPage.vue'),
+      },
+      {
+        path: 'lib/list/:listId/:entryId',
+        component: () => import('@/views/content/library/LibraryContentPage.vue'),
+        props: true
+      },
+      {
+        path: 'lib/list/:id',
+        component: () => import('@/views/content/LibrarySubListPage.vue'),
+        props: true
+      },
+      {
+        path: 'lib/entry/:entryId',
+        component: () => import('@/views/content/library/LibraryContentPage.vue'),
+        props: true
+      },
       {
         path: 'emergency',
         component: () => import('@/views/content/EmergencyPage.vue'),

--- a/src/stores/content.ts
+++ b/src/stores/content.ts
@@ -1,19 +1,46 @@
 import { medications } from '@/data/medications'
+import { libraryItems } from '@/data/library'
 import { Medication } from '@/types/medication';
+import { LibraryEntry } from '@/types/library-entry';
+import { LibraryList, LibraryListItem } from '@/types/library-list';
 import { defineStore } from 'pinia'
 
 export const useContentStore = defineStore('content', {
   state: () => ({
     medications,
+    library: libraryItems as LibraryListItem[],
   }),
   getters: {
     getMedications(state) {
       return state.medications
     },
+    getLibraryItems(state) {
+      return state.library
+    },
   },
   actions: {
-    findMedicationById(id: string): Medication|null {
+    findMedicationById(id: string): Medication | null {
       return this.medications.find(i => i.id === id) ?? null
+    },
+    findLibraryListById(id: string): LibraryList | null {
+      const item = this.library.find(entry => 'entries' in entry && entry.id === id)
+      return (item && 'entries' in item) ? item : null
+    },
+    findLibraryEntryById(id: string): LibraryEntry | null {
+      for (const item of this.library) {
+        if ('entries' in item) {
+          const found = item.entries.find(entry => entry.id === id)
+          if (found) { return found }
+        } else if (item.id === id) {
+          return item
+        }
+      }
+      return null
+    },
+    findLibraryEntryInList(listId: string, entryId: string): LibraryEntry | null {
+      const list = this.findLibraryListById(listId)
+      if (!list) { return null }
+      return list.entries.find(entry => entry.id === entryId) ?? null
     }
   }
 })

--- a/src/types/library-entry.ts
+++ b/src/types/library-entry.ts
@@ -1,0 +1,7 @@
+export interface LibraryEntry {
+  id: string;
+  title: string;
+  subtitle?: string;
+  path?: string;
+  component: () => Promise<any>;
+}

--- a/src/types/library-list.ts
+++ b/src/types/library-list.ts
@@ -1,0 +1,11 @@
+import { LibraryEntry } from './library-entry';
+
+export interface LibraryList {
+  id: string;
+  title: string;
+  subtitle?: string;
+  path?: string;
+  entries: LibraryEntry[];
+}
+
+export type LibraryListItem = LibraryEntry | LibraryList;

--- a/src/views/content/LibraryListPage.vue
+++ b/src/views/content/LibraryListPage.vue
@@ -1,0 +1,58 @@
+<template>
+  <ion-page>
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Wissen</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content :fullscreen="true" ref="mycontent">
+      <ion-header collapse="condense">
+        <ion-toolbar>
+          <ion-title size="large">Wissen</ion-title>
+        </ion-toolbar>
+      </ion-header>
+      <NsContentListContainer :items="items" />
+    </ion-content>
+  </ion-page>
+</template>
+
+<script setup lang="ts">
+import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar, onIonViewWillEnter } from '@ionic/vue'
+import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+import NsContentListContainer from '@/components/NsContentListContainer.vue'
+import { useContentStore } from '@/stores/content'
+
+const content = useContentStore()
+
+const items = computed(() =>
+  content.getLibraryItems.map(item => {
+    if ('entries' in item) {
+      return { ...item, path: `/tabs/lib/list/${item.id}` }
+    }
+    return { ...item, path: `/tabs/lib/entry/${item.id}` }
+  })
+)
+
+const mycontent = ref<{ $el: HTMLIonContentElement } | null>(null)
+const scrollPos = ref<number>(0)
+
+const router = useRouter()
+router.afterEach(async (to, from) => {
+  if (!mycontent.value) { return }
+
+  if (to.fullPath.includes('lib') && from.fullPath.includes('lib')) {
+    if (to.fullPath.length > from.fullPath.length) {
+      mycontent.value.$el.getScrollElement().then(el => {
+        scrollPos.value = el.scrollTop
+      })
+    }
+  }
+})
+
+onIonViewWillEnter(() => {
+  if (!mycontent.value) { return }
+  mycontent.value.$el.scrollToPoint(0, scrollPos.value, 400)
+})
+</script>

--- a/src/views/content/LibrarySubListPage.vue
+++ b/src/views/content/LibrarySubListPage.vue
@@ -1,0 +1,75 @@
+<template>
+  <ion-page>
+    <ion-header :translucent="true">
+      <ion-toolbar>
+        <ion-buttons slot="start">
+          <ion-back-button default-href="/tabs/lib" />
+        </ion-buttons>
+        <ion-title>{{ list?.title ?? 'Wissen' }}</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content :fullscreen="true" ref="mycontent">
+      <ion-header collapse="condense">
+        <ion-toolbar>
+          <ion-title size="large">{{ list?.title ?? 'Wissen' }}</ion-title>
+        </ion-toolbar>
+      </ion-header>
+      <NsContentListContainer v-if="entries.length" :items="entries" />
+      <div v-else class="empty-state">
+        <p>Es konnten keine Inhalte gefunden werden.</p>
+      </div>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script setup lang="ts">
+import { IonBackButton, IonButtons, IonContent, IonHeader, IonPage, IonTitle, IonToolbar, onIonViewWillEnter } from '@ionic/vue'
+import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+import NsContentListContainer from '@/components/NsContentListContainer.vue'
+import { useContentStore } from '@/stores/content'
+
+const props = defineProps<{ id: string }>()
+
+const content = useContentStore()
+
+const list = computed(() => content.findLibraryListById(props.id))
+
+const entries = computed(() => {
+  if (!list.value) { return [] }
+  return list.value.entries.map(entry => ({
+    ...entry,
+    path: `/tabs/lib/list/${list.value?.id}/${entry.id}`
+  }))
+})
+
+const mycontent = ref<{ $el: HTMLIonContentElement } | null>(null)
+const scrollPos = ref<number>(0)
+
+const router = useRouter()
+router.afterEach(async (to, from) => {
+  if (!mycontent.value) { return }
+
+  if (to.fullPath.includes('lib/list') && from.fullPath.includes('lib/list')) {
+    if (to.fullPath.length > from.fullPath.length) {
+      mycontent.value.$el.getScrollElement().then(el => {
+        scrollPos.value = el.scrollTop
+      })
+    }
+  }
+})
+
+onIonViewWillEnter(() => {
+  if (!mycontent.value) { return }
+  mycontent.value.$el.scrollToPoint(0, scrollPos.value, 400)
+})
+</script>
+
+<style scoped>
+.empty-state {
+  padding: 16px;
+  text-align: center;
+  color: var(--ion-color-medium);
+}
+</style>

--- a/src/views/content/library/LibraryContentPage.vue
+++ b/src/views/content/library/LibraryContentPage.vue
@@ -1,0 +1,61 @@
+<template>
+  <ion-page>
+    <ion-header :translucent="true">
+      <ion-toolbar>
+        <ion-buttons slot="start">
+          <ion-back-button :default-href="defaultHref"></ion-back-button>
+        </ion-buttons>
+        <ion-title>{{ entry?.title ?? 'Wissen' }}</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content :fullscreen="true">
+      <component v-if="entryComponent" :is="entryComponent" />
+      <div v-else class="empty-state">
+        <p>Der gewünschte Inhalt konnte nicht gefunden werden.</p>
+      </div>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script setup lang="ts">
+import { IonBackButton, IonButtons, IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/vue'
+import { computed, defineAsyncComponent } from 'vue'
+
+import { useContentStore } from '@/stores/content'
+
+const props = defineProps<{
+  entryId: string
+  listId?: string
+}>()
+
+const content = useContentStore()
+
+const entry = computed(() => {
+  if (props.listId) {
+    return content.findLibraryEntryInList(props.listId, props.entryId)
+  }
+  return content.findLibraryEntryById(props.entryId)
+})
+
+const entryComponent = computed(() => {
+  if (entry.value && entry.value.component) {
+    return defineAsyncComponent(entry.value.component)
+  }
+  return null
+})
+
+const defaultHref = computed(() => {
+  if (props.listId) {
+    return `/tabs/lib/list/${props.listId}`
+  }
+  return '/tabs/lib'
+})
+</script>
+
+<style scoped>
+.empty-state {
+  padding: 16px;
+  text-align: center;
+  color: var(--ion-color-medium);
+}
+</style>


### PR DESCRIPTION
## Summary
- add data structures and placeholder dataset for future library entries
- create library list, sub-list, and content views with navigation scaffolding
- wire up the router and store to surface library content and hierarchy

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d97b9e4edc832e8adcea1825936d72