### PR TITLE
Add specialized flow node variants

### DIFF
--- a/src/components/NsFlow.vue
+++ b/src/components/NsFlow.vue
@@ -41,16 +41,35 @@
           <g
             v-for="node in layout.nodes"
             :key="node.id"
-            class="ns-flow__node"
+            :class="[
+              'ns-flow__node',
+              `ns-flow__node--${node.nodeType}`,
+              { 'ns-flow__node--clickable': node.isClickable },
+            ]"
             :transform="`translate(${node.x}, ${node.y})`"
+            :tabindex="node.isClickable ? 0 : undefined"
+            :role="node.isClickable ? 'button' : undefined"
+            :aria-label="node.isClickable ? node.lines.join(' ') : undefined"
+            :focusable="node.isClickable ? 'true' : undefined"
+            @click="handleNodeActivate(node)"
+            @keydown.enter.prevent="handleNodeActivate(node)"
+            @keydown.space.prevent="handleNodeActivate(node)"
           >
-            <rect
-              class="ns-flow__node-box"
-              :width="layout.nodeSize.width"
-              :height="layout.nodeSize.height"
-              rx="14"
-              ry="14"
-            />
+            <template v-if="node.nodeType === 'decision'">
+              <polygon
+                class="ns-flow__node-shape"
+                :points="getDecisionPoints(layout.nodeSize)"
+              />
+            </template>
+            <template v-else>
+              <rect
+                class="ns-flow__node-shape"
+                :width="layout.nodeSize.width"
+                :height="layout.nodeSize.height"
+                :rx="getCornerRadius(node.nodeType, layout.nodeSize)"
+                :ry="getCornerRadius(node.nodeType, layout.nodeSize)"
+              />
+            </template>
             <foreignObject
               :width="layout.nodeSize.width"
               :height="layout.nodeSize.height"
@@ -63,6 +82,9 @@
                   class="ns-flow__node-line"
                 >
                   {{ line }}
+                </span>
+                <span v-if="node.quicktip" class="ns-flow__node-quicktip">
+                  {{ node.quicktip }}
                 </span>
               </div>
             </foreignObject>
@@ -78,8 +100,9 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useRouter } from 'vue-router'
 
-import type { NsFlowData, NsFlowEdge, NsFlowNode } from '@/types/flow'
+import type { NsFlowData, NsFlowEdge, NsFlowNode, NsFlowNodeType } from '@/types/flow'
 
 const props = defineProps<{ flow: NsFlowData }>()
 
@@ -89,6 +112,10 @@ interface LayoutNode extends NsFlowNode {
   column: number
   row: number
   lines: string[]
+  nodeType: NsFlowNodeType
+  quicktip?: string
+  linkPath?: string
+  isClickable: boolean
 }
 
 interface LayoutEdge extends NsFlowEdge {
@@ -106,6 +133,8 @@ interface LayoutResult {
 }
 
 const markerId = `ns-flow-arrow-${Math.random().toString(36).slice(2, 10)}`
+const router = useRouter()
+const NODE_TYPES = new Set<NsFlowNodeType>(['start-end', 'decision', 'process', 'task', 'link'])
 
 const layout = computed<LayoutResult>(() => {
   const fallback: LayoutResult = {
@@ -189,6 +218,11 @@ const layout = computed<LayoutResult>(() => {
     const column = levels.get(node.id) ?? 0
     const columnNodes = columns.get(column) ?? []
     columns.set(column, columnNodes)
+    const nodeType = resolveNodeType(node)
+    const quicktip = extractQuicktip(node)
+    const linkPath = extractLinkPath(node)
+    const isClickable = nodeType === 'link' && typeof linkPath === 'string'
+
     columnNodes.push({
       ...node,
       x: 0,
@@ -196,6 +230,10 @@ const layout = computed<LayoutResult>(() => {
       column,
       row: 0,
       lines: extractLines(node),
+      nodeType,
+      quicktip,
+      linkPath,
+      isClickable,
     })
   }
 
@@ -269,6 +307,61 @@ function extractLines(node: NsFlowNode): string[] {
     .filter(Boolean)
 }
 
+function extractQuicktip(node: NsFlowNode): string | undefined {
+  const quicktipCandidate = node.data?.quicktip
+  if (typeof quicktipCandidate !== 'string') {
+    return undefined
+  }
+
+  const trimmed = quicktipCandidate.trim()
+  return trimmed.length ? trimmed : undefined
+}
+
+function extractLinkPath(node: NsFlowNode): string | undefined {
+  const pathCandidate = node.data?.path
+  if (typeof pathCandidate !== 'string') {
+    return undefined
+  }
+
+  const trimmed = pathCandidate.trim()
+  return trimmed.length ? trimmed : undefined
+}
+
+function resolveNodeType(node: NsFlowNode): NsFlowNodeType {
+  if (NODE_TYPES.has(node.type as NsFlowNodeType)) {
+    return node.type as NsFlowNodeType
+  }
+  return 'process'
+}
+
+function handleNodeActivate(node: LayoutNode): void {
+  if (!node.isClickable || !node.linkPath) {
+    return
+  }
+
+  void router.push(node.linkPath)
+}
+
+function getDecisionPoints(size: LayoutResult['nodeSize']): string {
+  const halfWidth = size.width / 2
+  const halfHeight = size.height / 2
+  return `${halfWidth},0 ${size.width},${halfHeight} ${halfWidth},${size.height} 0,${halfHeight}`
+}
+
+function getCornerRadius(type: NsFlowNodeType, size: LayoutResult['nodeSize']): number {
+  switch (type) {
+    case 'start-end':
+      return size.height / 2
+    case 'link':
+      return 18
+    case 'task':
+      return 12
+    case 'process':
+    default:
+      return 12
+  }
+}
+
 </script>
 
 <style scoped>
@@ -300,10 +393,8 @@ function extractLines(node: NsFlowNode): string[] {
   font-family: inherit;
 }
 
-.ns-flow__node-box {
-  fill: var(--ion-color-light, #ffffff);
-  stroke: rgba(0, 0, 0, 0.08);
-  stroke-width: 1.5;
+.ns-flow__node {
+  outline: none;
 }
 
 .ns-flow__node-body {
@@ -326,6 +417,56 @@ function extractLines(node: NsFlowNode): string[] {
   display: block;
 }
 
+.ns-flow__node-quicktip {
+  font-size: 0.75rem;
+  font-weight: 500;
+  opacity: 0.9;
+}
+
+.ns-flow__node-shape {
+  stroke-width: 1.5;
+  stroke-linejoin: round;
+}
+
+.ns-flow__node--process .ns-flow__node-shape {
+  fill: #1767d1;
+  stroke: #0f4898;
+}
+
+.ns-flow__node--task .ns-flow__node-shape {
+  fill: #ffe38a;
+  stroke: #d9b246;
+}
+
+.ns-flow__node--start-end .ns-flow__node-shape {
+  fill: #f8d34c;
+  stroke: #c9a11f;
+}
+
+.ns-flow__node--decision .ns-flow__node-shape {
+  fill: #f6c94c;
+  stroke: #c5961b;
+}
+
+.ns-flow__node--link .ns-flow__node-shape {
+  fill: #f2994a;
+  stroke: #c06a18;
+}
+
+.ns-flow__node--process .ns-flow__node-body,
+.ns-flow__node--link .ns-flow__node-body {
+  color: #ffffff;
+}
+
+.ns-flow__node--clickable {
+  cursor: pointer;
+}
+
+.ns-flow__node--clickable:focus-visible {
+  outline: 2px solid var(--ion-color-primary, #1767d1);
+  outline-offset: 4px;
+}
+
 .ns-flow__empty {
   width: 100%;
   padding: 36px 16px;
@@ -345,13 +486,39 @@ function extractLines(node: NsFlowNode): string[] {
     box-shadow: 0 8px 18px rgba(0, 0, 0, 0.45);
   }
 
-  .ns-flow__node-box {
-    fill: rgba(20, 24, 32, 0.85);
-    stroke: rgba(255, 255, 255, 0.08);
+  .ns-flow__node--process .ns-flow__node-shape {
+    fill: #1f4fbf;
+    stroke: #122f7b;
+  }
+
+  .ns-flow__node--task .ns-flow__node-shape {
+    fill: #d5b534;
+    stroke: #9d8623;
+  }
+
+  .ns-flow__node--start-end .ns-flow__node-shape {
+    fill: #d7b234;
+    stroke: #9f8019;
+  }
+
+  .ns-flow__node--decision .ns-flow__node-shape {
+    fill: #d1a934;
+    stroke: #947519;
+  }
+
+  .ns-flow__node--link .ns-flow__node-shape {
+    fill: #d87725;
+    stroke: #9f5310;
   }
 
   .ns-flow__node-body {
     color: var(--ion-color-light, #f7f8fc);
+  }
+
+  .ns-flow__node--task .ns-flow__node-body,
+  .ns-flow__node--start-end .ns-flow__node-body,
+  .ns-flow__node--decision .ns-flow__node-body {
+    color: #1f2633;
   }
 
   .ns-flow__edge {

--- a/src/types/flow.ts
+++ b/src/types/flow.ts
@@ -1,9 +1,19 @@
+export type NsFlowNodeType = 'start-end' | 'decision' | 'process' | 'task' | 'link'
+
+export interface NsFlowNodeData {
+  label?: string
+  quicktip?: string
+  path?: string
+  [key: string]: unknown
+}
+
 export interface NsFlowNode {
   id: string
+  type?: NsFlowNodeType
   /**
    * Optional payload compatible with VueFlow default nodes.
    */
-  data?: Record<string, unknown>
+  data?: NsFlowNodeData
   /**
    * Convenience label if no data.label is supplied.
    */

--- a/src/views/content/library/bpr/airway/ContentAirway.vue
+++ b/src/views/content/library/bpr/airway/ContentAirway.vue
@@ -24,12 +24,29 @@ import type { NsFlowData } from '@/types/flow'
 
 const airwayFlow: NsFlowData = {
   nodes: [
-    { id: 'assessment', data: { label: 'Bewusstsein\nprüfen' } },
-    { id: 'open-airway', data: { label: 'Atemweg\nfreimachen' } },
+    { id: 'start', type: 'start-end', label: 'Startpunkt' },
+    { id: 'assessment', type: 'process', data: { label: 'Bewusstsein\nprüfen' } },
+    {
+      id: 'decision',
+      type: 'decision',
+      data: { label: 'Atmung\nvorhanden?', quicktip: '10 Sekunden prüfen' },
+    },
+    { id: 'open-airway', type: 'task', data: { label: 'Atemweg\nfreimachen' } },
+    { id: 'monitor', type: 'process', data: { label: 'Vitalparameter\nüberwachen' } },
+    {
+      id: 'library-link',
+      type: 'link',
+      data: { label: 'Weitere Infos zur Beatmung', path: '/tabs/lib' },
+    },
+    { id: 'end', type: 'start-end', data: { label: 'Behandlung\nabschließen' } },
   ],
   edges: [
-    { source: 'assessment', target: 'open-airway' },
-    { source: 'open-airway', target: 'ventilate' },
+    { source: 'start', target: 'assessment' },
+    { source: 'assessment', target: 'decision' },
+    { source: 'decision', target: 'open-airway' },
+    { source: 'open-airway', target: 'monitor' },
+    { source: 'monitor', target: 'library-link' },
+    { source: 'library-link', target: 'end' },
   ],
 }
 </script>


### PR DESCRIPTION
## Summary
- add typed flow node variants for start/end, decision, process, task, and link states
- render variant-specific shapes, quick tips, and routing logic inside NsFlow
- showcase the new node types in the airway workflow data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d989ec8bfc832ea7c2a6a244b4b022