### PR TITLE
Add key-value layout components

### DIFF
--- a/src/components/NsKeyValue.vue
+++ b/src/components/NsKeyValue.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="ns-key-value">
+    <div class="ns-key-value__cell ns-key-value__cell--key">
+      <ns-text-content>
+        <em class="ns-key-value__key">{{ label }}</em>
+      </ns-text-content>
+    </div>
+    <div class="ns-key-value__cell ns-key-value__cell--value">
+      <ns-text-content>
+        <slot></slot>
+      </ns-text-content>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { defineProps } from 'vue';
+import NsTextContent from './NsTextContent.vue';
+
+defineProps<{ label: string }>();
+</script>
+
+<style scoped>
+.ns-key-value__key {
+  font-style: italic;
+  font-weight: inherit;
+}
+</style>

--- a/src/components/NsKeyValueContainer.vue
+++ b/src/components/NsKeyValueContainer.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="ns-key-value-container">
+    <div class="ns-key-value-table">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+
+</script>
+
+<style scoped>
+.ns-key-value-table {
+  display: table;
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+:deep(.ns-key-value) {
+  display: table-row;
+}
+
+:deep(.ns-key-value__cell) {
+  display: table-cell;
+  vertical-align: top;
+  padding: 0.25rem 0;
+}
+
+:deep(.ns-key-value__cell--key) {
+  width: 50%;
+  max-width: 50%;
+  padding-right: 1.5rem;
+}
+
+:deep(.ns-key-value__cell--value) {
+  width: auto;
+}
+</style>


### PR DESCRIPTION
## Summary
- add an `NsKeyValue` component for rendering italicized keys alongside value content slots
- introduce an `NsKeyValueContainer` that aligns key/value rows with a table-like layout and shared key column width

## Testing
- npm run lint *(fails: ESLint requires migration to eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68da8f4ea6e0832e8e85b06d78273496