### PR TITLE
Add NsColorBox component for inline color swatches

### DIFF
--- a/src/components/NsColorBox.vue
+++ b/src/components/NsColorBox.vue
@@ -1,0 +1,52 @@
+<template>
+  <span class="ns-color-box" :style="boxStyle" aria-hidden="true"></span>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{
+  colorKey: string
+}>()
+
+const normalizeKey = (key: string): string => key.trim()
+
+const backgroundColor = computed(() => {
+  const key = normalizeKey(props.colorKey)
+
+  if (!key)
+    return 'transparent'
+
+  const lowerKey = key.toLowerCase()
+
+  if (lowerKey.startsWith('#') || lowerKey.startsWith('rgb') || lowerKey.startsWith('hsl'))
+    return key
+
+  if (key.startsWith('--'))
+    return `var(${key})`
+
+  return `var(--ns-broselow-code-${key}, var(--ns-color-${key}, ${key}))`
+})
+
+const boxStyle = computed(() => ({
+  backgroundColor: backgroundColor.value,
+}))
+</script>
+
+<style scoped>
+.ns-color-box {
+  display: inline-block;
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 2px;
+  vertical-align: middle;
+  margin-inline-end: 0.4rem;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+@media (prefers-color-scheme: dark) {
+  .ns-color-box {
+    border-color: rgba(255, 255, 255, 0.2);
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- add an NsColorBox component that renders a small inline color swatch using CSS variables and fallbacks

## Testing
- npm run build *(fails: vue-tsc: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68da95500c1c832e9a317bbe1b65924b