### PR TITLE
Add toolbar search for medication list

### DIFF
--- a/src/views/content/MedsListPage.vue
+++ b/src/views/content/MedsListPage.vue
@@ -3,32 +3,88 @@
     <ion-header>
       <ion-toolbar>
         <ion-title>Medikamente</ion-title>
+        <ion-buttons slot="end">
+          <ion-button fill="clear" @click="toggleSearch">
+            <ion-icon :icon="isSearchVisible ? closeOutline : searchOutline" slot="icon-only" />
+          </ion-button>
+        </ion-buttons>
+      </ion-toolbar>
+      <ion-toolbar v-if="isSearchVisible">
+        <ion-searchbar
+          ref="searchbar"
+          v-model="searchTerm"
+          placeholder="Suche"
+          show-clear-button="focus"
+          :debounce="200"
+        />
       </ion-toolbar>
     </ion-header>
     <ion-content :fullscreen="true" ref="mycontent">
       <ion-header collapse="condense">
         <ion-toolbar>
           <ion-title size="large">Medikamente</ion-title>
+          <ion-buttons slot="end">
+            <ion-button fill="clear" @click="toggleSearch">
+              <ion-icon :icon="isSearchVisible ? closeOutline : searchOutline" slot="icon-only" />
+            </ion-button>
+          </ion-buttons>
         </ion-toolbar>
       </ion-header>
-      <NsContentListContainer :items="medications" />
+      <template v-if="filteredMedications.length">
+        <NsContentListContainer :items="filteredMedications" />
+      </template>
+      <div v-else class="empty-state">
+        <ion-icon :icon="searchOutline" />
+        <ion-text>Keine Medikamente gefunden.</ion-text>
+      </div>
     </ion-content>
   </ion-page>
 </template>
 
 <script setup lang="ts">
 
-import { IonPage, IonHeader, IonToolbar, IonIcon, IonTitle, IonContent, onIonViewWillEnter } from '@ionic/vue';
+import { IonPage, IonHeader, IonToolbar, IonIcon, IonTitle, IonContent, IonButtons, IonButton, IonSearchbar, IonText, onIonViewWillEnter } from '@ionic/vue';
 
 import { useContentStore } from '@/stores/content'
-import { ref, computed } from 'vue'
+import { ref, computed, nextTick } from 'vue'
 import { useRouter } from 'vue-router'
 
 import NsContentListContainer from '@/components/NsContentListContainer.vue';
 
+import { closeOutline, searchOutline } from 'ionicons/icons'
+
 const content = useContentStore()
 
+const searchTerm = ref('')
+const isSearchVisible = ref(false)
+
+const searchbar = ref<{ $el: HTMLIonSearchbarElement } | null>(null)
+
 const medications = computed(() => content.getMedications.map(i => ({ ...i, path: `/tabs/meds/${i.id}` })) )
+
+const filteredMedications = computed(() => {
+  const term = searchTerm.value.trim().toLowerCase()
+  if (!term) {
+    return medications.value
+  }
+  return medications.value.filter(item => {
+    const title = item.title.toLowerCase()
+    const subtitle = item.subtitle?.toLowerCase() ?? ''
+    return title.includes(term) || subtitle.includes(term)
+  })
+})
+
+const toggleSearch = async () => {
+  if (isSearchVisible.value) {
+    isSearchVisible.value = false
+    searchTerm.value = ''
+    return
+  }
+  isSearchVisible.value = true
+  await nextTick()
+  if (!searchbar.value) { return }
+  searchbar.value.$el.setFocus()
+}
 
 // #region ScrollPosition
 
@@ -58,3 +114,19 @@ const medications = computed(() => content.getMedications.map(i => ({ ...i, path
 // #endregion
 
 </script>
+
+<style scoped>
+.empty-state {
+  margin-top: 4rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--ion-color-medium);
+}
+
+.empty-state ion-icon {
+  font-size: 2.5rem;
+}
+</style>
+


### PR DESCRIPTION
## Summary
- add a toolbar search toggle to the medication list page and filter items by the query
- show an empty state message when no medications match the search
- focus the search bar when opened and keep the condensed header button consistent

## Testing
- npm run build *(fails: existing type errors in unrelated files such as NsDosageIndication.vue, NsSideeffect.vue, EmergencyPage.vue, and ContentGlucose.vue)*

------
https://chatgpt.com/codex/tasks/task_e_68dba05b8b3c832e8a64784b5c3d3ace