### PR TITLE
Fix component imports and patient binding

### DIFF
--- a/src/components/medications/NsDosageIndication.vue
+++ b/src/components/medications/NsDosageIndication.vue
@@ -22,7 +22,7 @@
 import { IonIcon } from '@ionic/vue'
 import { medical } from 'ionicons/icons'
 
-import NsContentSplit from './NsContentSplit.vue'
+import NsContentSplit from '@/components/NsContentSplit.vue'
 
 defineProps<{
   name?: string,

--- a/src/components/medications/NsSideeffect.vue
+++ b/src/components/medications/NsSideeffect.vue
@@ -15,7 +15,7 @@
 import { IonButton, IonIcon } from '@ionic/vue'
 import { caretForward, arrowForwardOutline } from 'ionicons/icons'
 import { computed } from 'vue'
-import NsListItem from './NsListItem.vue'
+import NsListItem from '@/components/NsListItem.vue'
 
 const props = defineProps<{
   severe?: boolean,

--- a/src/views/content/EmergencyPage.vue
+++ b/src/views/content/EmergencyPage.vue
@@ -40,7 +40,7 @@ import NsPatientInput from '../../components/emergency/NsPatientInput.vue';
 import NsPatientInfo from '../../components/emergency/NsPatientInfo.vue';
 
 import { useContentStore } from '@/stores/content'
-import { ref, computed } from 'vue'
+import { computed, ref, shallowRef } from 'vue'
 import { useRouter } from 'vue-router'
 
 import NsContentGroup from '@/components/NsContentGroup.vue';
@@ -86,7 +86,11 @@ const medications = computed(() => content.getMedications.map(i => ({ ...i, path
 
 // #region Patient
 
-  const currentPatient = ref<Patient>(new Patient())
+  const currentPatientRef = shallowRef(new Patient())
+  const currentPatient = computed({
+    get: () => currentPatientRef.value,
+    set: (value: Patient) => { currentPatientRef.value = value },
+  })
 
 // #endregion
 

--- a/src/views/content/medications/glucose/ContentGlucose.vue
+++ b/src/views/content/medications/glucose/ContentGlucose.vue
@@ -9,7 +9,7 @@
 
     <ns-content-group title="Kontraindikation">
       <ns-list>
-        <ns-contraindication type="invisible"><b>Keine</b></ns-contraindication>
+        <ns-contraindication type="none"><b>Keine</b></ns-contraindication>
       </ns-list>
     </ns-content-group>
 


### PR DESCRIPTION
## Summary
- update medication component imports to use the shared alias
- adjust glucose contraindication type to a supported value
- fix the emergency patient binding to use a shallow ref-backed computed value

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dba8bcb074832ea4bdf8284237b2c7