### PR TITLE
Add medications settings modal trigger

### DIFF
--- a/src/views/content/medications/MedsContentPage.vue
+++ b/src/views/content/medications/MedsContentPage.vue
@@ -1,30 +1,56 @@
 <template>
-  <ion-page>
+  <ion-page ref="pageRef">
     <ion-header :translucent="true">
       <ion-toolbar>
         <ion-buttons slot="start">
           <ion-back-button @click="back"></ion-back-button>
         </ion-buttons>
         <ion-title>{{ medication?.title }}</ion-title>
+        <ion-buttons slot="end">
+          <ion-button fill="clear" @click="openSettings">
+            <ion-icon :icon="settingsOutline" slot="icon-only" />
+          </ion-button>
+        </ion-buttons>
       </ion-toolbar>
     </ion-header>
     <ion-content :fullscreen="true">
       <component v-if="medicationComponent" :is="medicationComponent" :medication="medication" />
     </ion-content>
+    <ion-modal
+      :is-open="isSettingsOpen"
+      :presenting-element="presentingElement"
+      @didDismiss="closeSettings"
+    >
+      <MedsSettings @close="closeSettings" />
+    </ion-modal>
   </ion-page>
 </template>
 
 <script setup lang="ts">
 
-import { IonPage, IonHeader, IonToolbar, IonTitle, IonContent, IonButtons, IonBackButton } from '@ionic/vue';
+import {
+  IonPage,
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonContent,
+  IonButtons,
+  IonBackButton,
+  IonButton,
+  IonIcon,
+  IonModal
+} from '@ionic/vue';
 import { useContentStore } from '@/stores/content'
 import { ref, computed, defineAsyncComponent } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { settingsOutline } from 'ionicons/icons'
+import MedsSettings from './MedsSettings.vue'
 
 const route = useRoute()
 const router = useRouter()
 const content = useContentStore()
 
+const pageRef = ref<{ $el: HTMLElement } | null>(null)
 const medicationId = ref(Array.isArray(route.params.id) ? route.params.id[0] : route.params.id)
 const medication = ref(content.findMedicationById(medicationId.value))
 
@@ -34,6 +60,17 @@ const medicationComponent = computed(() => {
   }
   return null;
 })
+
+const presentingElement = computed(() => pageRef.value?.$el)
+const isSettingsOpen = ref(false)
+
+const openSettings = () => {
+  isSettingsOpen.value = true
+}
+
+const closeSettings = () => {
+  isSettingsOpen.value = false
+}
 
 const back = () => {
   router.back()

--- a/src/views/content/medications/MedsSettings.vue
+++ b/src/views/content/medications/MedsSettings.vue
@@ -1,0 +1,42 @@
+<template>
+  <ion-page>
+    <ion-header :translucent="true">
+      <ion-toolbar>
+        <ion-title>Medikament-Einstellungen</ion-title>
+        <ion-buttons slot="end">
+          <ion-button fill="clear" @click="close">
+            <ion-icon :icon="closeOutline" slot="icon-only" />
+          </ion-button>
+        </ion-buttons>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="ion-padding">
+      <ion-text color="medium">
+        Weitere Einstellungen werden hier in Zukunft verfügbar sein.
+      </ion-text>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script setup lang="ts">
+import {
+  IonPage,
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonButtons,
+  IonButton,
+  IonIcon,
+  IonContent,
+  IonText
+} from '@ionic/vue';
+import { closeOutline } from 'ionicons/icons'
+
+const emit = defineEmits<{
+  (e: 'close'): void
+}>()
+
+const close = () => {
+  emit('close')
+}
+</script>


### PR DESCRIPTION
## Summary
- add a settings button to the medication detail toolbar that opens a modal
- implement the new MedsSettings modal component with placeholder content

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbe0a45efc832e93c7ab22d2512e81