### PR TITLE
Normalize medication package identifiers

### DIFF
--- a/src/data/medications.ts
+++ b/src/data/medications.ts
@@ -6,7 +6,7 @@ export const medications: Medication[] =[
     title: 'Acetylsalicylsäure',
     subtitle: 'ASS, Aspirin, Aspisol',
     packages: {
-      'iv-set': <Package>{
+      'iv_500mg': <Package>{
         type: 'amp-flsk',
         name: 'Set „Aspirin”',
         incredients: [
@@ -28,7 +28,7 @@ export const medications: Medication[] =[
     title: 'Amiodaron',
     subtitle: 'Cordarex, Cordarone',
     packages: {
-      'iv-150mg-3ml': <Package>{
+      'iv_150mg': <Package>{
         type: 'amp',
         name: 'Ampulle „Amiodaron”',
         incredients: [
@@ -43,7 +43,7 @@ export const medications: Medication[] =[
     id: 'atropin',
     title: 'Atropin',
     packages: {
-      'iv-0.5mg-1ml': <Package>{
+      'iv_0_5mg': <Package>{
         type: 'amp',
         name: 'Ampulle „Atropin”',
         incredients: [
@@ -58,7 +58,7 @@ export const medications: Medication[] =[
     title: 'Butylscopolamin',
     subtitle: 'Buscopan',
     packages: {
-      'iv-20mg-1ml': <Package>{
+      'iv_20mg': <Package>{
         type: 'amp',
         name: 'Ampulle „Butylscopolamin”',
         incredients: [
@@ -73,21 +73,21 @@ export const medications: Medication[] =[
     title: 'Dimenhydrinat',
     subtitle: 'Vomex A',
     packages: {
-      'iv-62mg-10ml': <Package>{
+      'iv_62mg': <Package>{
         type: 'amp',
         name: 'Ampulle „Dimenhydrinat”',
         incredients: [
           <PackageIncredient>{ amount: '62mg / 10ml' },
         ]
       },
-      'supp-40mg': <Package>{
+      'supp_40mg': <Package>{
         type: 'supp',
         name: 'Zäpfchen „Vomex A”',
         incredients: [
           <PackageIncredient>{ amount: '40mg' },
         ]
       },
-      'supp-70mg': <Package>{
+      'supp_70mg': <Package>{
         type: 'supp',
         name: 'Zäpfchen „Vomex A”',
         incredients: [
@@ -102,7 +102,7 @@ export const medications: Medication[] =[
     title: 'Dimetinden',
     subtitle: 'Fenistil, Histakut',
     packages: {
-      'iv-4mg-4ml': <Package>{
+      'iv_4mg': <Package>{
         type: 'amp',
         name: 'Ampulle „Histakut”',
         incredients: [
@@ -117,7 +117,7 @@ export const medications: Medication[] =[
     title: 'Adrenalin',
     subtitle: 'Epinephrin, Suprarenin',
     packages: {
-      'iv-1mg-1ml': <Package>{
+      'iv_1mg': <Package>{
         type: 'amp',
         name: 'Ampulle „Adrenalin”',
         incredients: [
@@ -134,21 +134,21 @@ export const medications: Medication[] =[
     title: 'Esketamin',
     subtitle: 'Ketanest S',
     packages: {
-      'iv-5mg-ml--5ml': <Package>{
+      'iv_5mgml_5ml': <Package>{
         type: 'amp',
         name: 'Ampulle „Esketamin”',
         incredients: [
           <PackageIncredient>{ amount: '5mg/ml (5ml)' },
         ]
       },
-      'iv-25mg-ml--2ml': <Package>{
+      'iv_25mgml_2ml': <Package>{
         type: 'amp',
         name: 'Ampulle „Esketamin”',
         incredients: [
           <PackageIncredient>{ amount: '25mg/ml (2ml)' },
         ]
       },
-      'iv-25mg-ml--10ml': <Package>{
+      'iv_25mgml_10ml': <Package>{
         type: 'amp',
         name: 'Ampulle „Esketamin”',
         incredients: [
@@ -162,14 +162,14 @@ export const medications: Medication[] =[
     id: 'fentanyl',
     title: 'Fentanyl',
     packages: {
-      'iv-01mg-2ml': <Package>{
+      'iv_0_05mgml_2ml': <Package>{
         type: 'amp',
         name: 'Ampulle „Fentanyl”',
         incredients: [
           <PackageIncredient>{ amount: '0,1mg/2ml' },
         ]
       },
-      'iv-05mg-10ml': <Package>{
+      'iv_0_05mgml_10ml': <Package>{
         type: 'amp',
         name: 'Ampulle „Fentanyl”',
         incredients: [
@@ -184,14 +184,14 @@ export const medications: Medication[] =[
     title: 'Furosemid',
     subtitle: 'Furesis, Lasix',
     packages: {
-      'iv-20mg-2ml': <Package>{
+      'iv_20mg': <Package>{
         type: 'amp',
         name: 'Ampulle „Furosemid”',
         incredients: [
           <PackageIncredient>{ amount: '20mg / 2ml',  },
         ]
       },
-      'iv-40mg-4ml': <Package>{
+      'iv_40mg': <Package>{
         type: 'amp',
         name: 'Ampulle „Furosemid”',
         incredients: [
@@ -205,7 +205,7 @@ export const medications: Medication[] =[
     id: 'glucagon',
     title: 'Glucagon',
     packages: {
-      'im-1mg-1ml': <Package>{
+      'im_1mg': <Package>{
         type: 'spritz',
         name: 'Fertig-Set „Glucagon”',
         incredients: [
@@ -213,7 +213,7 @@ export const medications: Medication[] =[
           <PackageIncredient>{ amount: '+ 1ml', label: 'Wasser (Spritze)' },
         ]
       },
-      'nasal-3mg': <Package>{
+      'nasal_3mg': <Package>{
         type: 'spray',
         name: 'Nasenspray „baqsimi”',
         incredients: [
@@ -227,21 +227,21 @@ export const medications: Medication[] =[
     id: 'glucose',
     title: 'Glucose',
     packages: {
-      'iv-g10': <Package>{
+      'iv_1g_10ml': <Package>{
         type: 'flexamp',
         name: 'Ampulle „G10”',
         incredients: [
           <PackageIncredient>{ amount: '1g/10ml',  },
         ]
       },
-      'iv-g20': <Package>{
+      'iv_2g_10ml': <Package>{
         type: 'flexamp',
         name: 'Ampulle „G20”',
         incredients: [
           <PackageIncredient>{ amount: '2g/10ml' },
         ]
       },
-      'iv-g40': <Package>{
+      'iv_4g_10ml': <Package>{
         type: 'flexamp',
         name: 'Ampulle „G40”',
         incredients: [
@@ -256,7 +256,7 @@ export const medications: Medication[] =[
     title: 'Glyceroltrinitrat',
     subtitle: 'Nitro',
     packages: {
-      'spray-nitro': <Package>{
+      'spray_0_4mg': <Package>{
         type: 'spray',
         name: 'Spray „Nitro”',
         incredients: [
@@ -270,21 +270,21 @@ export const medications: Medication[] =[
     id: 'heparin',
     title: 'Heparin',
     packages: {
-      'iv-25000-ml--0.2ml': <Package>{
+      'iv_25000ieml_0_2ml': <Package>{
         type: 'amp',
         name: 'Ampulle „Heparin”',
         incredients: [
           <PackageIncredient>{ amount: ' 5.000IE (0.2ml)' },
         ]
       },
-      'iv-5000-ml--5ml': <Package>{
+      'iv_5000ieml_5ml': <Package>{
         type: 'amp',
         name: 'Ampulle „Heparin”',
         incredients: [
           <PackageIncredient>{ amount: '25.000IE (5ml)' },
         ]
       },
-      'iv-5000-ml--1ml': <Package>{
+      'iv_5000ieml_1ml': <Package>{
         type: 'amp',
         name: 'Ampulle „Heparin”',
         incredients: [
@@ -299,7 +299,7 @@ export const medications: Medication[] =[
     title: 'Ibuprofen',
     subtitle: 'Nurofen',
     packages: {
-      'po-tabl': <Package>{
+      'po_200mg_400mg_600mg_800mg': <Package>{
         type: 'pill',
         name: 'Ibuprofen-Tabletten',
         incredients: [
@@ -307,7 +307,7 @@ export const medications: Medication[] =[
           <PackageIncredient>{ amount: '600mg. 800mg', label: '(rezeptpflichtig)' },
         ]
       },
-      'po-saft': <Package>{
+      'po_20mgml_40mgml': <Package>{
         type: 'flsk',
         name: 'Ibuprofen-Saft',
         incredients: [
@@ -315,7 +315,7 @@ export const medications: Medication[] =[
           <PackageIncredient>{ amount: ' 40mg / ml' },
         ]
       },
-      'supp': <Package>{
+      'supp_75mg_125mg_150mg_250mg': <Package>{
         type: 'supp',
         name: 'Ibuprofen-Zäpfchen',
         incredients: [
@@ -323,7 +323,7 @@ export const medications: Medication[] =[
           <PackageIncredient>{ amount: '150mg, 250mg' },
         ]
       },
-      'iv-flask': <Package>{
+      'iv_4mgml_6mgml_100ml': <Package>{
         type: 'infusion',
         name: 'Kurzinfusionen',
         incredients: [
@@ -339,14 +339,14 @@ export const medications: Medication[] =[
     title: 'Ipratropiumbromid',
     subtitle: 'Atrovent',
     packages: {
-      'pi-250': <Package>{
+      'inh_250ug': <Package>{
         type: 'flexamp',
         name: 'Ampulle „Atrovent”',
         incredients: [
           <PackageIncredient>{ amount: '250µg / 2ml' },
         ]
       },
-      'pi-500': <Package>{
+      'inh_500ug': <Package>{
         type: 'flexamp',
         name: 'Ampulle „Atrovent”',
         incredients: [
@@ -361,7 +361,7 @@ export const medications: Medication[] =[
     title: 'Metoprolol',
     subtitle: 'Beloc',
     packages: {
-      'iv-5mg-5ml': <Package>{
+      'iv_5mg': <Package>{
         type: 'amp',
         name: 'Ampulle „Metoprolol”',
         incredients: [
@@ -377,28 +377,28 @@ export const medications: Medication[] =[
     title: 'Midazolam',
     subtitle: 'Dormicum',
     packages: {
-      'iv-5mg-ml--1ml': <Package>{
+      'iv_5mgml_1ml': <Package>{
         type: 'amp',
         name: 'Ampulle Midazolam',
         incredients: [
           <PackageIncredient>{ amount: '5mg / ml (1ml)' }
         ]
       },
-      'iv-1mg-ml--5ml': <Package>{
+      'iv_1mgml_5ml': <Package>{
         type: 'amp',
         name: 'Ampulle Midazolam',
         incredients: [
           <PackageIncredient>{ amount: '1mg / ml (5ml)' }
         ]
       },
-      'iv-5mg-ml--3ml': <Package>{
+      'iv_5mgml_3ml': <Package>{
         type: 'amp',
         name: 'Ampulle Midazolam',
         incredients: [
           <PackageIncredient>{ amount: '5mg / ml (3ml)' }
         ]
       },
-      'buccolam': <Package>{
+      'buccal_2_5mg_5mg_7_5mg_10mg': <Package>{
         type: 'spritz',
         name: 'Buccolam Fertigspritzen',
         incredients: [
@@ -415,14 +415,14 @@ export const medications: Medication[] =[
     id: 'morphin',
     title: 'Morphin',
     packages: {
-      'iv-10mg-1ml': <Package>{
+      'iv_10mg': <Package>{
         type: 'amp',
         name: 'Ampulle Morphin',
         incredients: [
           <PackageIncredient>{ amount: '10mg / 1ml' },
         ]
       },
-      'iv-20mg-1ml': <Package>{
+      'iv_20mg': <Package>{
         type: 'amp',
         name: 'Ampulle Morphin',
         incredients: [
@@ -436,7 +436,7 @@ export const medications: Medication[] =[
     id: 'nalbuphin',
     title: 'Nalbuphin',
     packages: {
-      'iv-20mg-2ml': <Package>{
+      'iv_20mg': <Package>{
         type: 'amp',
         name: 'Ampulle Nalbuphin',
         incredients: [
@@ -450,7 +450,7 @@ export const medications: Medication[] =[
     id: 'naloxon',
     title: 'Naloxon',
     packages: {
-      'iv-04mg-1ml': <Package>{
+      'iv_0_4mg': <Package>{
         type: 'amp',
         name: 'Ampulle Naloxon',
         incredients: [
@@ -465,28 +465,28 @@ export const medications: Medication[] =[
     title: 'Paracetamol',
     subtitle: 'Perfalgan',
     packages: {
-      'po-tabl': <Package>{
+      'po_500mg': <Package>{
         type: 'pill',
         name: 'Paracetamol-Tablette',
         incredients: [
           <PackageIncredient>{ amount: '500mg' }
         ]
       },
-      'po-saft': <Package>{
+      'po_40mgml': <Package>{
         type: 'flsk',
         name: 'Paracetamol-Saft',
         incredients: [
           <PackageIncredient>{ amount: '40mg / ml' }
         ]
       },
-      'supp': <Package>{
+      'supp_125mg_250mg': <Package>{
         type: 'supp',
         name: 'Paracetamol-Zäpfchen',
         incredients: [
           <PackageIncredient>{ amount: '125mg, 250mg' }
         ]
       },
-      'iv-flask': <Package>{
+      'iv_10mgml_100ml': <Package>{
         type: 'infusion',
         name: 'Kurzinfusionen',
         incredients: [
@@ -501,14 +501,14 @@ export const medications: Medication[] =[
     title: 'Prednisolon',
     subtitle: 'Prednisolut',
     packages: {
-      'supp': <Package>{
+      'supp_100mg': <Package>{
         type: 'supp',
         name: 'Zäpfchen „Rectodelt”',
         incredients: [
           <PackageIncredient>{ amount: '100mg' }
         ]
       },
-      'iv-100mg': <Package>{
+      'iv_100mg': <Package>{
         type: 'amp-2x',
         name: 'Set „Prednisolut”',
         incredients: [
@@ -516,7 +516,7 @@ export const medications: Medication[] =[
           <PackageIncredient>{ amount: '+  2ml', label: 'Wasser' },
         ]
       },
-      'iv-250mg': <Package>{
+      'iv_250mg': <Package>{
         type: 'amp-flsk',
         name: 'Set „Prednisolut”',
         incredients: [
@@ -531,7 +531,7 @@ export const medications: Medication[] =[
     id: 'salbutamol',
     title: 'Salbutamol',
     packages: {
-      'verneb': <Package>{
+      'inh_5mgml': <Package>{
         type: 'flexamp',
         name: 'Inhalationslösung Salbutamol',
         incredients: [
@@ -545,14 +545,14 @@ export const medications: Medication[] =[
     id: 'tranexam',
     title: 'Tranexamsäure',
     packages: {
-      'iv-500mg-5ml': <Package>{
+      'iv_100mgml_5ml': <Package>{
         type: 'amp',
         name: 'Ampulle Tranexamsäure',
         incredients: [
           <PackageIncredient>{ amount: '100mg / ml (5ml)' }
         ]
       },
-      'iv-1000mg-10ml': <Package>{
+      'iv_100mgml_10ml': <Package>{
         type: 'amp',
         name: 'Ampulle Tranexamsäure',
         incredients: [
@@ -567,14 +567,14 @@ export const medications: Medication[] =[
     title: 'Urapidil',
     subtitle: 'Ebrantil',
     packages: {
-      'iv-5mg-ml--5ml': <Package>{
+      'iv_5mgml_5ml': <Package>{
         type: 'amp',
         name: 'Ampulle Urapidil',
         incredients: [
           <PackageIncredient>{ amount: '5mg / ml (5ml)' }
         ]
       },
-      'iv-5mg-ml--10ml': <Package>{
+      'iv_5mgml_10ml': <Package>{
         type: 'amp',
         name: 'Ampulle Urapidil',
         incredients: [

--- a/src/views/content/medications/acetylsalicyl/ContentAcetylsalicyl.vue
+++ b/src/views/content/medications/acetylsalicyl/ContentAcetylsalicyl.vue
@@ -71,7 +71,7 @@
 
     <ns-content-group title="Einsatz & Dosierung">
 
-      <ns-package :package="defaultPackage"></ns-package>
+      <ns-package :package="iv_500mg"></ns-package>
 
       <ns-dosage-indication name="Akutes Koronarsyndrom">
         <ns-dosage-usage type="iv">
@@ -132,7 +132,7 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const defaultPackage = computed(() => props.medication.packages['iv-set'])
+const iv_500mg = computed(() => props.medication.packages['iv_500mg'])
 
 </script>
 

--- a/src/views/content/medications/amiodaron/ContentAmiodaron.vue
+++ b/src/views/content/medications/amiodaron/ContentAmiodaron.vue
@@ -22,7 +22,7 @@
 
     <ns-content-group title="Einsatz & Dosierung">
 
-      <ns-package :package="defaultPackage"></ns-package>
+      <ns-package :package="iv_150mg"></ns-package>
 
       <ns-dosage-indication name="Reanimation">
         <ns-dosage-usage type="iv">
@@ -91,7 +91,7 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const defaultPackage = computed(() => props.medication.packages['iv-150mg-3ml'])
+const iv_150mg = computed(() => props.medication.packages['iv_150mg'])
 
 </script>
 

--- a/src/views/content/medications/atropin/ContentAtropin.vue
+++ b/src/views/content/medications/atropin/ContentAtropin.vue
@@ -52,7 +52,7 @@
 
     <ns-content-group title="Einsatz & Dosierung">
 
-      <ns-package :package="defaultPackage"></ns-package>
+      <ns-package :package="iv_0_5mg"></ns-package>
 
       <ns-dosage-indication name="Bradykardie">
         <ns-dosage-usage type="iv">
@@ -117,7 +117,7 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const defaultPackage = computed(() => props.medication.packages['iv-0.5mg-1ml'])
+const iv_0_5mg = computed(() => props.medication.packages['iv_0_5mg'])
 
 </script>
 

--- a/src/views/content/medications/butylscopolamin/ContentButylscopolamin.vue
+++ b/src/views/content/medications/butylscopolamin/ContentButylscopolamin.vue
@@ -76,7 +76,7 @@
 
     <ns-content-group title="Einsatz & Dosierung">
 
-      <ns-package :package="defaultPackage"></ns-package>
+      <ns-package :package="iv_20mg"></ns-package>
 
       <ns-dosage-indication name="Kolikartiger Schmerz">
         <ns-dosage-usage type="invisible">
@@ -156,7 +156,7 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const defaultPackage = computed(() => props.medication.packages['iv-20mg-1ml'])
+const iv_20mg = computed(() => props.medication.packages['iv_20mg'])
 
 </script>
 

--- a/src/views/content/medications/dimenhydrinat/ContentDimenhydrinat.vue
+++ b/src/views/content/medications/dimenhydrinat/ContentDimenhydrinat.vue
@@ -94,9 +94,9 @@
 
     <ns-content-group title="Einsatz & Dosierung">
 
-      <ns-package :package="defaultPackage"></ns-package>
-      <ns-package v-if="isSupp40Enabled" :package="supp40Package"></ns-package>
-      <ns-package v-if="isSupp70Enabled" :package="supp70Package"></ns-package>
+      <ns-package :package="iv_62mg"></ns-package>
+      <ns-package v-if="isSupp40Enabled" :package="supp_40mg"></ns-package>
+      <ns-package v-if="isSupp70Enabled" :package="supp_70mg"></ns-package>
 
       <ns-dosage-indication name="Übelkeit & Erbrechen">
         <ns-dosage-usage type="iv">
@@ -177,9 +177,9 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const defaultPackage = computed(() => props.medication.packages['iv-62mg-10ml'])
-const supp40Package = computed(() => props.medication.packages['supp-40mg'])
-const supp70Package = computed(() => props.medication.packages['supp-70mg'])
+const iv_62mg = computed(() => props.medication.packages['iv_62mg'])
+const supp_40mg = computed(() => props.medication.packages['supp_40mg'])
+const supp_70mg = computed(() => props.medication.packages['supp_70mg'])
 
 const isSupp40Enabled = computed(() => false)
 const isSupp70Enabled = computed(() => false)

--- a/src/views/content/medications/dimetinden/ContentDimetinden.vue
+++ b/src/views/content/medications/dimetinden/ContentDimetinden.vue
@@ -60,7 +60,7 @@
 
     <ns-content-group title="Einsatz & Dosierung">
 
-      <ns-package :package="defaultPackage"></ns-package>
+      <ns-package :package="iv_4mg"></ns-package>
 
       <ns-dosage-indication name="Anaphylaxie">
         <ns-dosage-usage type="iv">
@@ -116,7 +116,7 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const defaultPackage = computed(() => props.medication.packages['iv-4mg-4ml'])
+const iv_4mg = computed(() => props.medication.packages['iv_4mg'])
 
 </script>
 

--- a/src/views/content/medications/epinephrin/ContentEpinephrin.vue
+++ b/src/views/content/medications/epinephrin/ContentEpinephrin.vue
@@ -34,7 +34,7 @@
 
     <ns-content-group title="Einsatz & Dosierung">
 
-      <ns-package :package="defaultPackage"></ns-package>
+      <ns-package :package="iv_1mg"></ns-package>
 
       <ns-dosage-indication name="Reanimation">
         <ns-dosage-usage type="invisible">
@@ -160,7 +160,7 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const defaultPackage = computed(() => props.medication.packages['iv-1mg-1ml'])
+const iv_1mg = computed(() => props.medication.packages['iv_1mg'])
 
 </script>
 

--- a/src/views/content/medications/esketamin/ContentEsketamin.vue
+++ b/src/views/content/medications/esketamin/ContentEsketamin.vue
@@ -94,9 +94,9 @@
 
     <ns-content-group title="Einsatz & Dosierung">
 
-      <ns-package v-if="isiv5_5mlEnabled" :package="iv5_5ml"></ns-package>
-      <ns-package v-if="isiv25_2mlEnabled" :package="iv25_2ml"></ns-package>
-      <ns-package v-if="isiv25_10mlEnabled" :package="iv25_10ml"></ns-package>
+      <ns-package v-if="isIv_5mgml_5mlEnabled" :package="iv_5mgml_5ml"></ns-package>
+      <ns-package v-if="isIv_25mgml_2mlEnabled" :package="iv_25mgml_2ml"></ns-package>
+      <ns-package v-if="isIv_25mgml_10mlEnabled" :package="iv_25mgml_10ml"></ns-package>
 
       <ns-dosage-indication name="Stärkste Schmerzen">
         <ns-dosage-usage type="iv">
@@ -112,18 +112,18 @@
           <h2>Aufziehen</h2>
           <p>Um <i>Fehldosierung</i> zu vermeiden, immer gleiche Konzentration (<text-mono>2,5mg/ml</text-mono>) benutzen, dazu:
           </p>
-          <ns-package v-if="isiv5_5mlEnabled"
-            :package="iv5_5ml" :inline-specs="{
+          <ns-package v-if="isIv_5mgml_5mlEnabled"
+            :package="iv_5mgml_5ml" :inline-specs="{
             on: 10,
             onlyOne: onlyOneEnabled }">
           </ns-package>
-          <ns-package v-else-if="isiv25_2mlEnabled"
-            :package="iv25_2ml" :inline-specs="{
+          <ns-package v-else-if="isIv_25mgml_2mlEnabled"
+            :package="iv_25mgml_2ml" :inline-specs="{
             on: 20,
             onlyOne: onlyOneEnabled }">
           </ns-package>
-          <ns-package v-else-if="isiv25_10mlEnabled"
-            :package="iv25_10ml" :inline-specs="{
+          <ns-package v-else-if="isIv_25mgml_10mlEnabled"
+            :package="iv_25mgml_10ml" :inline-specs="{
             on: 10, off: 2,
             onlyOne: onlyOneEnabled }">
           </ns-package>
@@ -163,9 +163,9 @@
             Um Applikation zu vereinfachen, geeignete Konzentration wählen und nur benötigte Menge <b>½-ml</b>-weise aufziehen.
           </p>
           <hr>
-          <template v-if="isiv5_5mlEnabled">
-            <ns-package v-if="isiv5_5mlEnabled"
-              :package="iv5_5ml" :inline-specs="{
+          <template v-if="isIv_5mgml_5mlEnabled">
+            <ns-package v-if="isIv_5mgml_5mlEnabled"
+              :package="iv_5mgml_5ml" :inline-specs="{
               onlyOne: onlyOneEnabled }">
             </ns-package>
             <p style="margin-left: 1.2rem">
@@ -176,15 +176,15 @@
             </p>
             <hr>
           </template>
-          <template v-if="isiv25_2mlEnabled || isiv25_10mlEnabled">
+          <template v-if="isIv_25mgml_2mlEnabled || isIv_25mgml_10mlEnabled">
 
-            <ns-package v-if="isiv25_2mlEnabled"
-              :package="iv25_2ml" :inline-specs="{
+            <ns-package v-if="isIv_25mgml_2mlEnabled"
+              :package="iv_25mgml_2ml" :inline-specs="{
               on: 5,
               onlyOne: onlyOneEnabled }">
             </ns-package>
             <ns-package v-else
-              :package="iv25_10ml" :inline-specs="{
+              :package="iv_25mgml_10ml" :inline-specs="{
               off: 2, on: 5,
               onlyOne: onlyOneEnabled }">
             </ns-package>
@@ -196,12 +196,12 @@
             </p>
             <hr>
 
-            <ns-package v-if="isiv25_2mlEnabled"
-              :package="iv25_2ml" :inline-specs="{
+            <ns-package v-if="isIv_25mgml_2mlEnabled"
+              :package="iv_25mgml_2ml" :inline-specs="{
               onlyOne: onlyOneEnabled }">
             </ns-package>
             <ns-package v-else
-              :package="iv25_10ml" :inline-specs="{
+              :package="iv_25mgml_10ml" :inline-specs="{
               off: 2,
               onlyOne: onlyOneEnabled }">
             </ns-package>
@@ -276,14 +276,14 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv5_5ml = computed(() => props.medication.packages['iv-5mg-ml--5ml'])
-const iv25_2ml = computed(() => props.medication.packages['iv-25mg-ml--2ml'])
-const iv25_10ml = computed(() => props.medication.packages['iv-25mg-ml--10ml'])
+const iv_5mgml_5ml = computed(() => props.medication.packages['iv_5mgml_5ml'])
+const iv_25mgml_2ml = computed(() => props.medication.packages['iv_25mgml_2ml'])
+const iv_25mgml_10ml = computed(() => props.medication.packages['iv_25mgml_10ml'])
 
-const isiv5_5mlEnabled = computed(() => true)
-const isiv25_2mlEnabled = computed(() => true)
-const isiv25_10mlEnabled = computed(() => true)
-const onlyOneEnabled = computed(() => [ isiv5_5mlEnabled.value, isiv25_2mlEnabled.value, isiv25_10mlEnabled.value ].filter(Boolean).length === 1)
+const isIv_5mgml_5mlEnabled = computed(() => true)
+const isIv_25mgml_2mlEnabled = computed(() => true)
+const isIv_25mgml_10mlEnabled = computed(() => true)
+const onlyOneEnabled = computed(() => [ isIv_5mgml_5mlEnabled.value, isIv_25mgml_2mlEnabled.value, isIv_25mgml_10mlEnabled.value ].filter(Boolean).length === 1)
 
 const onlySAA = computed(() => false) /* TODO: onlySAA-Trigger */
 

--- a/src/views/content/medications/fentanyl/ContentFentanyl.vue
+++ b/src/views/content/medications/fentanyl/ContentFentanyl.vue
@@ -60,8 +60,8 @@
 
     <ns-content-group title="Einsatz & Dosierung">
 
-      <ns-package :package="iv01mg" v-if="isiv01Enabled"></ns-package>
-      <ns-package :package="iv05mg" v-if="isiv05Enabled"></ns-package>
+      <ns-package :package="iv_0_05mgml_2ml" v-if="isIv_0_05mgml_2mlEnabled"></ns-package>
+      <ns-package :package="iv_0_05mgml_10ml" v-if="isIv_0_05mgml_10mlEnabled"></ns-package>
 
       <ns-dosage-indication name="Stärkste Schmerzen">
         <ns-dosage-usage type="invisible">
@@ -159,11 +159,11 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv01mg = computed(() => props.medication.packages['iv-01mg-2ml'])
-const iv05mg = computed(() => props.medication.packages['iv-05mg-10ml'])
+const iv_0_05mgml_2ml = computed(() => props.medication.packages['iv_0_05mgml_2ml'])
+const iv_0_05mgml_10ml = computed(() => props.medication.packages['iv_0_05mgml_10ml'])
 
-const isiv01Enabled = computed(() => true)
-const isiv05Enabled = computed(() => true)
+const isIv_0_05mgml_2mlEnabled = computed(() => true)
+const isIv_0_05mgml_10mlEnabled = computed(() => true)
 
 const onlySAA = computed(() => false) /* TODO: onlySAA-Trigger */
 

--- a/src/views/content/medications/furosemid/ContentFurosemid.vue
+++ b/src/views/content/medications/furosemid/ContentFurosemid.vue
@@ -45,8 +45,8 @@
 
     <ns-content-group title="Einsatz & Dosierung">
 
-      <ns-package :package="iv20mg" v-if="isIv20mgEnabled"></ns-package>
-      <ns-package :package="iv40mg" v-if="isIv40mgEnabled"></ns-package>
+      <ns-package :package="iv_20mg" v-if="isIv_20mgEnabled"></ns-package>
+      <ns-package :package="iv_40mg" v-if="isIv_40mgEnabled"></ns-package>
 
       <ns-dosage-indication name="Kardiales Lungenödem">
         <ns-dosage-usage type="iv">
@@ -58,7 +58,7 @@
             </template>
           </div>
           <div v-if="!onlyOneEnabled" style="display:flex">
-            <ns-package inline :package="iv20mg"></ns-package> <b>ganz.</b>
+            <ns-package inline :package="iv_20mg"></ns-package> <b>ganz.</b>
           </div>
           <div v-if="!onlyOneEnabled" style="display:flex">
             <ns-package inline :package="iv40mg"></ns-package> <b>zur Hälfte.</b>
@@ -116,12 +116,12 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv20mg = computed(() => props.medication.packages['iv-20mg-2ml'])
-const iv40mg = computed(() => props.medication.packages['iv-40mg-4ml'])
+const iv_20mg = computed(() => props.medication.packages['iv_20mg'])
+const iv_40mg = computed(() => props.medication.packages['iv_40mg'])
 
-const isIv20mgEnabled = computed(() => true)
-const isIv40mgEnabled = computed(() => true)
-const onlyOneEnabled = computed(() => [ isIv20mgEnabled.value, isIv40mgEnabled.value ].filter(Boolean).length === 1)
+const isIv_20mgEnabled = computed(() => true)
+const isIv_40mgEnabled = computed(() => true)
+const onlyOneEnabled = computed(() => [ isIv_20mgEnabled.value, isIv_40mgEnabled.value ].filter(Boolean).length === 1)
 
 const onlySAA = computed(() => false) /* TODO: onlySAA-Trigger */
 

--- a/src/views/content/medications/glucagon/ContentGlucagon.vue
+++ b/src/views/content/medications/glucagon/ContentGlucagon.vue
@@ -45,11 +45,11 @@
 
     <ns-content-group title="Einsatz & Dosierung">
 
-      <ns-package :package="imGl" v-if="isImGlEnabled"></ns-package>
-      <ns-package :package="inGl" v-if="isInGlEnabled"></ns-package>
+      <ns-package :package="im_1mg" v-if="isIm_1mgEnabled"></ns-package>
+      <ns-package :package="nasal_3mg" v-if="isNasal_3mgEnabled"></ns-package>
 
       <ns-dosage-indication name="Hypoglykämie">
-        <ns-dosage-usage type="im" v-if="isImGlEnabled">
+        <ns-dosage-usage type="im" v-if="isIm_1mgEnabled">
           <div>
             <ns-dosage :dosage="{
               target: '> 25kg (8J)', color: 'blue',
@@ -61,7 +61,7 @@
             </ns-dosage>
           </div>
         </ns-dosage-usage>
-        <ns-dosage-usage type="nasal" v-if="isInGlEnabled">
+        <ns-dosage-usage type="nasal" v-if="isNasal_3mgEnabled">
           <h2>Ab 4 Jahren</h2>
           <div>
             <ns-dosage :dosage="{ dose: '3mg', hint: '(Ganzes Nasenspray)' }"></ns-dosage>
@@ -115,12 +115,12 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const imGl = computed(() => props.medication.packages['im-1mg-1ml'])
-const inGl = computed(() => props.medication.packages['nasal-3mg'])
+const im_1mg = computed(() => props.medication.packages['im_1mg'])
+const nasal_3mg = computed(() => props.medication.packages['nasal_3mg'])
 
-const isImGlEnabled = computed(() => true)
-const isInGlEnabled = computed(() => true)
-const onlyOneEnabled = computed(() => [ isImGlEnabled.value, isInGlEnabled.value ].filter(Boolean).length === 1)
+const isIm_1mgEnabled = computed(() => true)
+const isNasal_3mgEnabled = computed(() => true)
+const onlyOneEnabled = computed(() => [ isIm_1mgEnabled.value, isNasal_3mgEnabled.value ].filter(Boolean).length === 1)
 
 const onlySAA = computed(() => false) /* TODO: onlySAA-Trigger */
 
@@ -128,7 +128,7 @@ const onlySAA = computed(() => false) /* TODO: onlySAA-Trigger */
 const onsetText = computed(() => {
   if (onlyOneEnabled.value)
   {
-    if (isImGlEnabled.value) {
+    if (isIm_1mgEnabled.value) {
       return '10-30 Minuten'
     } else {
       return 'Ca. 15 Minuten'

--- a/src/views/content/medications/glucose/ContentGlucose.vue
+++ b/src/views/content/medications/glucose/ContentGlucose.vue
@@ -27,9 +27,9 @@
 
     <ns-content-group title="Einsatz & Dosierung">
 
-      <ns-package :package="g10" v-if="isG10Enabled"></ns-package>
-      <ns-package :package="g20" v-if="isG20Enabled"></ns-package>
-      <ns-package :package="g40" v-if="isG40Enabled"></ns-package>
+      <ns-package :package="iv_1g_10ml" v-if="isIv_1g_10mlEnabled"></ns-package>
+      <ns-package :package="iv_2g_10ml" v-if="isIv_2g_10mlEnabled"></ns-package>
+      <ns-package :package="iv_4g_10ml" v-if="isIv_4g_10mlEnabled"></ns-package>
 
       <ns-dosage-indication name="Hypoglykämie">
         <ns-dosage-usage type="iv">
@@ -94,23 +94,23 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const g10 = computed(() => props.medication.packages['iv-g10'])
-const g20 = computed(() => props.medication.packages['iv-g20'])
-const g40 = computed(() => props.medication.packages['iv-g40'])
+const iv_1g_10ml = computed(() => props.medication.packages['iv_1g_10ml'])
+const iv_2g_10ml = computed(() => props.medication.packages['iv_2g_10ml'])
+const iv_4g_10ml = computed(() => props.medication.packages['iv_4g_10ml'])
 
-const isG10Enabled = computed(() => true)
-const isG20Enabled = computed(() => true)
-const isG40Enabled = computed(() => true)
-const onlyOneEnabled = computed(() => [ isG10Enabled.value, isG20Enabled.value, isG40Enabled.value ].filter(Boolean).length === 1)
+const isIv_1g_10mlEnabled = computed(() => true)
+const isIv_2g_10mlEnabled = computed(() => true)
+const isIv_4g_10mlEnabled = computed(() => true)
+const onlyOneEnabled = computed(() => [ isIv_1g_10mlEnabled.value, isIv_2g_10mlEnabled.value, isIv_4g_10mlEnabled.value ].filter(Boolean).length === 1)
 
 const onlySAA = computed(() => false) /* TODO: onlySAA-Trigger */
 
 const doseAdultHint = computed(() => {
   if (onlyOneEnabled.value)
   {
-    if (isG10Enabled.value) { return '(8 Ampullen)' }
-    if (isG20Enabled.value) { return '(4 Ampullen)' }
-    if (isG40Enabled.value) { return '(2 Ampullen)'}
+    if (isIv_1g_10mlEnabled.value) { return '(8 Ampullen)' }
+    if (isIv_2g_10mlEnabled.value) { return '(4 Ampullen)' }
+    if (isIv_4g_10mlEnabled.value) { return '(2 Ampullen)'}
   }
   return ''
 })

--- a/src/views/content/medications/glyceroltrinitrat/ContentGlyceroltrinitrat.vue
+++ b/src/views/content/medications/glyceroltrinitrat/ContentGlyceroltrinitrat.vue
@@ -66,7 +66,7 @@
 
     <ns-content-group title="Einsatz & Dosierung">
 
-      <ns-package :package="nitro"></ns-package>
+      <ns-package :package="spray_0_4mg"></ns-package>
 
       <ns-dosage-indication>
         <ns-dosage-usage type="po">
@@ -131,7 +131,7 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const nitro = computed(() => props.medication.packages['spray-nitro'])
+const spray_0_4mg = computed(() => props.medication.packages['spray_0_4mg'])
 
 const onlySAA = computed(() => false) /* TODO: onlySAA-Trigger */
 

--- a/src/views/content/medications/heparin/ContentHeparin.vue
+++ b/src/views/content/medications/heparin/ContentHeparin.vue
@@ -55,9 +55,9 @@
 
     <ns-content-group title="Einsatz & Dosierung">
 
-      <ns-package :package="iv25000_02ml" v-if="isIv25000_02mlEnabled"></ns-package>
-      <ns-package :package="iv5000_1ml" v-if="isIv5000_1mlEnabled"></ns-package>
-      <ns-package :package="iv5000_5ml" v-if="isIv5000_5mlEnabled"></ns-package>
+      <ns-package :package="iv_25000ieml_0_2ml" v-if="isIv_25000ieml_0_2mlEnabled"></ns-package>
+      <ns-package :package="iv_5000ieml_1ml" v-if="isIv_5000ieml_1mlEnabled"></ns-package>
+      <ns-package :package="iv_5000ieml_5ml" v-if="isIv_5000ieml_5mlEnabled"></ns-package>
 
       <ns-dosage-indication>
         <ns-dosage-usage type="iv">
@@ -113,18 +113,18 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv25000_02ml = computed(() => props.medication.packages['iv-25000-ml--0.2ml'])
-const iv5000_5ml = computed(() => props.medication.packages['iv-5000-ml--5ml'])
-const iv5000_1ml = computed(() => props.medication.packages['iv-5000-ml--1ml'])
+const iv_25000ieml_0_2ml = computed(() => props.medication.packages['iv_25000ieml_0_2ml'])
+const iv_5000ieml_5ml = computed(() => props.medication.packages['iv_5000ieml_5ml'])
+const iv_5000ieml_1ml = computed(() => props.medication.packages['iv_5000ieml_1ml'])
 
-const isIv25000_02mlEnabled = computed(() => false)
-const isIv5000_5mlEnabled = computed(() => true)
-const isIv5000_1mlEnabled = computed(() => false)
-const onlyOneEnabled = computed(() => [ isIv25000_02mlEnabled.value, isIv5000_5mlEnabled.value, isIv5000_1mlEnabled.value ].filter(Boolean).length === 1)
+const isIv_25000ieml_0_2mlEnabled = computed(() => false)
+const isIv_5000ieml_5mlEnabled = computed(() => true)
+const isIv_5000ieml_1mlEnabled = computed(() => false)
+const onlyOneEnabled = computed(() => [ isIv_25000ieml_0_2mlEnabled.value, isIv_5000ieml_5mlEnabled.value, isIv_5000ieml_1mlEnabled.value ].filter(Boolean).length === 1)
 
 const onlySAA = computed(() => false) /* TODO: onlySAA-Trigger */
 
-const hasToWarn = computed(() => isIv5000_5mlEnabled.value)
+const hasToWarn = computed(() => isIv_5000ieml_5mlEnabled.value)
 const doseHint = computed(() => {
   if (hasToWarn.value)
   {

--- a/src/views/content/medications/ibuprofen/ContentIbuprofen.vue
+++ b/src/views/content/medications/ibuprofen/ContentIbuprofen.vue
@@ -66,10 +66,10 @@
 
     <ns-content-group title="Einsatz & Dosierung">
 
-      <ns-package :package="poTabl" v-if="isPoTablEnabled"></ns-package>
-      <ns-package :package="poSaft" v-if="isPoSaftEnabled"></ns-package>
-      <ns-package :package="supp" v-if="isSuppEnabled"></ns-package>
-      <ns-package :package="ivFlask" v-if="isIvFlaskEnabled"></ns-package>
+      <ns-package :package="po_200mg_400mg_600mg_800mg" v-if="isPo_200mg_400mg_600mg_800mgEnabled"></ns-package>
+      <ns-package :package="po_20mgml_40mgml" v-if="isPo_20mgml_40mgmlEnabled"></ns-package>
+      <ns-package :package="supp_75mg_125mg_150mg_250mg" v-if="isSupp_75mg_125mg_150mg_250mgEnabled"></ns-package>
+      <ns-package :package="iv_4mgml_6mgml_100ml" v-if="isIv_4mgml_6mgml_100mlEnabled"></ns-package>
 
       <ns-dosage-indication>
         <ns-dosage-usage type="invisible">
@@ -150,22 +150,22 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const poTabl = computed(() => props.medication.packages['po-tabl'])
-const poSaft = computed(() => props.medication.packages['po-saft'])
-const supp = computed(() => props.medication.packages['supp'])
-const ivFlask = computed(() => props.medication.packages['iv-flask'])
+const po_200mg_400mg_600mg_800mg = computed(() => props.medication.packages['po_200mg_400mg_600mg_800mg'])
+const po_20mgml_40mgml = computed(() => props.medication.packages['po_20mgml_40mgml'])
+const supp_75mg_125mg_150mg_250mg = computed(() => props.medication.packages['supp_75mg_125mg_150mg_250mg'])
+const iv_4mgml_6mgml_100ml = computed(() => props.medication.packages['iv_4mgml_6mgml_100ml'])
 
-const isPoTablEnabled = computed(() => true)
-const isPoSaftEnabled = computed(() => true)
-const isSuppEnabled = computed(() => true)
-const isIvFlaskEnabled = computed(() => true)
-const onlyOneEnabled = computed(() => [ isPoTablEnabled.value, isPoSaftEnabled.value, isSuppEnabled.value, isIvFlaskEnabled.value ].filter(Boolean).length === 1)
+const isPo_200mg_400mg_600mg_800mgEnabled = computed(() => true)
+const isPo_20mgml_40mgmlEnabled = computed(() => true)
+const isSupp_75mg_125mg_150mg_250mgEnabled = computed(() => true)
+const isIv_4mgml_6mgml_100mlEnabled = computed(() => true)
+const onlyOneEnabled = computed(() => [ isPo_200mg_400mg_600mg_800mgEnabled.value, isPo_20mgml_40mgmlEnabled.value, isSupp_75mg_125mg_150mg_250mgEnabled.value, isIv_4mgml_6mgml_100mlEnabled.value ].filter(Boolean).length === 1)
 
 const onlySAA = computed(() => false) /* TODO: onlySAA-Trigger */
 
-const hasPo = computed(() => isPoTablEnabled.value || isPoSaftEnabled.value)
-const hasSupp = computed(() => isSuppEnabled.value)
-const hasIv = computed(() => isIvFlaskEnabled.value)
+const hasPo = computed(() => isPo_200mg_400mg_600mg_800mgEnabled.value || isPo_20mgml_40mgmlEnabled.value)
+const hasSupp = computed(() => isSupp_75mg_125mg_150mg_250mgEnabled.value)
+const hasIv = computed(() => isIv_4mgml_6mgml_100mlEnabled.value)
 
 const onsetText = computed(() => {
   const one = onlyOneEnabled.value

--- a/src/views/content/medications/ipratropiumbromid/ContentIpratropiumbromid.vue
+++ b/src/views/content/medications/ipratropiumbromid/ContentIpratropiumbromid.vue
@@ -60,8 +60,8 @@
 
     <ns-content-group title="Einsatz & Dosierung">
 
-      <ns-package :package="pi250" v-if="isPi250Enabled"></ns-package>
-      <ns-package :package="pi500" v-if="isPi500Enabled"></ns-package>
+      <ns-package :package="inh_250ug" v-if="isInh_250ugEnabled"></ns-package>
+      <ns-package :package="inh_500ug" v-if="isInh_500ugEnabled"></ns-package>
 
       <ns-dosage-indication>
         <ns-dosage-usage type="pi">
@@ -130,12 +130,12 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const pi250 = computed(() => props.medication.packages['pi-250'])
-const pi500 = computed(() => props.medication.packages['pi-500'])
+const inh_250ug = computed(() => props.medication.packages['inh_250ug'])
+const inh_500ug = computed(() => props.medication.packages['inh_500ug'])
 
-const isPi250Enabled = computed(() => false)
-const isPi500Enabled = computed(() => true)
-const onlyOneEnabled = computed(() => [ isPi250Enabled.value, isPi500Enabled.value ].filter(Boolean).length === 1)
+const isInh_250ugEnabled = computed(() => false)
+const isInh_500ugEnabled = computed(() => true)
+const onlyOneEnabled = computed(() => [ isInh_250ugEnabled.value, isInh_500ugEnabled.value ].filter(Boolean).length === 1)
 
 const onlySAA = computed(() => false) /* TODO: onlySAA-Trigger */
 
@@ -143,8 +143,8 @@ const ampAmount = (dose: number) => {
   if (onlyOneEnabled.value)
   {
     let size = 1
-    if (isPi250Enabled.value) { size = 0.25 }
-    else if (isPi500Enabled.value) { size = 0.5 }
+    if (isInh_250ugEnabled.value) { size = 0.25 }
+    else if (isInh_500ugEnabled.value) { size = 0.5 }
     const amount = dose/size
     return `(${amount==0.5 ? '½' : amount} Ampulle${amount<=1 ? '' : 'n'})`
   }

--- a/src/views/content/medications/metoprolol/ContentMetoprolol.vue
+++ b/src/views/content/medications/metoprolol/ContentMetoprolol.vue
@@ -63,7 +63,7 @@
 
     <ns-content-group title="Einsatz & Dosierung">
 
-      <ns-package :package="iv5mg5ml"></ns-package>
+      <ns-package :package="iv_5mg"></ns-package>
 
       <ns-dosage-indication>
         <ns-dosage-usage type="iv">
@@ -125,7 +125,7 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv5mg5ml = computed(() => props.medication.packages['iv-5mg-5ml'])
+const iv_5mg = computed(() => props.medication.packages['iv_5mg'])
 
 const onlySAA = computed(() => false) /* TODO: onlySAA-Trigger */
 

--- a/src/views/content/medications/midazolam/ContentMidazolam.vue
+++ b/src/views/content/medications/midazolam/ContentMidazolam.vue
@@ -60,10 +60,10 @@
 
     <ns-content-group title="Einsatz & Dosierung">
 
-      <ns-package :package="iv5_1" v-if="isIv5_1Enabled"></ns-package>
-      <ns-package :package="iv1_5" v-if="isIv1_5Enabled"></ns-package>
-      <ns-package :package="iv5_3" v-if="isIv5_3Enabled"></ns-package>
-      <ns-package :package="buccl" v-if="isBucclEnabled"></ns-package>
+      <ns-package :package="iv_5mgml_1ml" v-if="isIv_5mgml_1mlEnabled"></ns-package>
+      <ns-package :package="iv_1mgml_5ml" v-if="isIv_1mgml_5mlEnabled"></ns-package>
+      <ns-package :package="iv_5mgml_3ml" v-if="isIv_5mgml_3mlEnabled"></ns-package>
+      <ns-package :package="buccal_2_5mg_5mg_7_5mg_10mg" v-if="isBuccal_2_5mg_5mg_7_5mg_10mgEnabled"></ns-package>
 
       <ns-dosage-indication name="Krampfanfall">
 
@@ -75,7 +75,7 @@
           </p>
         </ns-dosage-usage>
 
-        <ns-dosage-usage type="po" v-if="isBucclEnabled">
+        <ns-dosage-usage type="po" v-if="isBuccal_2_5mg_5mg_7_5mg_10mgEnabled">
 
           <h2>Buccale Gabe</h2>
           <div>
@@ -131,17 +131,17 @@
           <h2>Aufziehen</h2>
           <p>Um <i>Fehldosierung</i> zu vermeiden, immer gleiche Konzentration (<text-mono>1mg/ml</text-mono>)benutzen, dazu:
           </p>
-          <ns-package v-if="isIv1_5Enabled"
-            :package="iv1_5" :inline-specs="{
+          <ns-package v-if="isIv_1mgml_5mlEnabled"
+            :package="iv_1mgml_5ml" :inline-specs="{
             onlyOne: onlyOneIvEnabled }">
           </ns-package>
-          <ns-package v-if="isIv5_1Enabled"
-            :package="iv5_1" :inline-specs="{
+          <ns-package v-if="isIv_5mgml_1mlEnabled"
+            :package="iv_5mgml_1ml" :inline-specs="{
             on: 5,
             onlyOne: onlyOneIvEnabled }">
           </ns-package>
-          <ns-package v-if="isIv5_3Enabled"
-            :package="iv5_3" :inline-specs="{
+          <ns-package v-if="isIv_5mgml_3mlEnabled"
+            :package="iv_5mgml_3ml" :inline-specs="{
             on: 5, off: 1,
             onlyOne: onlyOneIvEnabled }">
           </ns-package>
@@ -236,24 +236,24 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv5_1 = computed(() => props.medication.packages['iv-5mg-ml--1ml'])
-const iv5_3 = computed(() => props.medication.packages['iv-5mg-ml--3ml'])
-const iv1_5 = computed(() => props.medication.packages['iv-1mg-ml--5ml'])
-const buccl = computed(() => props.medication.packages['buccolam'])
+const iv_5mgml_1ml = computed(() => props.medication.packages['iv_5mgml_1ml'])
+const iv_5mgml_3ml = computed(() => props.medication.packages['iv_5mgml_3ml'])
+const iv_1mgml_5ml = computed(() => props.medication.packages['iv_1mgml_5ml'])
+const buccal_2_5mg_5mg_7_5mg_10mg = computed(() => props.medication.packages['buccal_2_5mg_5mg_7_5mg_10mg'])
 
-const isIv5_1Enabled = computed(() => true)
-const isIv5_3Enabled = computed(() => true)
-const isIv1_5Enabled = computed(() => true)
+const isIv_5mgml_1mlEnabled = computed(() => true)
+const isIv_5mgml_3mlEnabled = computed(() => true)
+const isIv_1mgml_5mlEnabled = computed(() => true)
 
-const isBucclEnabled = computed(() => true)
+const isBuccal_2_5mg_5mg_7_5mg_10mgEnabled = computed(() => true)
 
-const onlyOneEnabled = computed(() => [ onlyOneIvEnabled.value, isBucclEnabled.value ].filter(Boolean).length === 1)
-const onlyOneIvEnabled = computed(() => [ isIv5_1Enabled.value, isIv5_3Enabled.value, isIv1_5Enabled.value ].filter(Boolean).length === 1)
+const onlyOneEnabled = computed(() => [ onlyOneIvEnabled.value, isBuccal_2_5mg_5mg_7_5mg_10mgEnabled.value ].filter(Boolean).length === 1)
+const onlyOneIvEnabled = computed(() => [ isIv_5mgml_1mlEnabled.value, isIv_5mgml_3mlEnabled.value, isIv_1mgml_5mlEnabled.value ].filter(Boolean).length === 1)
 
 const onlySAA = computed(() => false) /* TODO: onlySAA-Trigger */
 
-const hasIv = computed(() => isIv1_5Enabled.value || isIv5_1Enabled.value || isIv5_3Enabled.value)
-const hasBuc = computed(() => isBucclEnabled.value)
+const hasIv = computed(() => isIv_1mgml_5mlEnabled.value || isIv_5mgml_1mlEnabled.value || isIv_5mgml_3mlEnabled.value)
+const hasBuc = computed(() => isBuccal_2_5mg_5mg_7_5mg_10mgEnabled.value)
 
 const onsetText = computed(() => {
   let one = onlyOneEnabled.value

--- a/src/views/content/medications/morphin/ContentMorphin.vue
+++ b/src/views/content/medications/morphin/ContentMorphin.vue
@@ -60,8 +60,8 @@
 
     <ns-content-group title="Einsatz & Dosierung">
 
-      <ns-package :package="iv10_1" v-if="isIv10_1Enabled"></ns-package>
-      <ns-package :package="iv20_1" v-if="isIv20_1Enabled"></ns-package>
+      <ns-package :package="iv_10mg" v-if="isIv_10mgEnabled"></ns-package>
+      <ns-package :package="iv_20mg" v-if="isIv_20mgEnabled"></ns-package>
 
       <ns-dosage-indication name="Schmerzen">
         <ns-dosage-usage type="iv">
@@ -69,13 +69,13 @@
           <h2>Aufziehen</h2>
           <p>Um <i>Fehldosierung</i> zu vermeiden, immer gleiche Konzentration (<text-mono>1mg/ml</text-mono>) benutzen, dazu:
           </p>
-          <ns-package v-if="isIv10_1Enabled"
-            :package="iv10_1" :inline-specs="{
+          <ns-package v-if="isIv_10mgEnabled"
+            :package="iv_10mg" :inline-specs="{
             on: 10,
             onlyOne: onlyOneEnabled }">
           </ns-package>
-          <ns-package v-if="isIv20_1Enabled"
-            :package="iv20_1" :inline-specs="{
+          <ns-package v-if="isIv_20mgEnabled"
+            :package="iv_20mg" :inline-specs="{
             on: 20,
             onlyOne: onlyOneEnabled }">
           </ns-package>
@@ -145,13 +145,13 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv10_1 = computed(() => props.medication.packages['iv-10mg-1ml'])
-const iv20_1 = computed(() => props.medication.packages['iv-20mg-1ml'])
+const iv_10mg = computed(() => props.medication.packages['iv_10mg'])
+const iv_20mg = computed(() => props.medication.packages['iv_20mg'])
 
-const isIv10_1Enabled = computed(() => true)
-const isIv20_1Enabled = computed(() => true)
+const isIv_10mgEnabled = computed(() => true)
+const isIv_20mgEnabled = computed(() => true)
 
-const onlyOneEnabled = computed(() => [ isIv10_1Enabled.value, isIv20_1Enabled.value ].filter(Boolean).length === 1)
+const onlyOneEnabled = computed(() => [ isIv_10mgEnabled.value, isIv_20mgEnabled.value ].filter(Boolean).length === 1)
 
 const onlySAA = computed(() => false) /* TODO: onlySAA-Trigger */
 

--- a/src/views/content/medications/nalbuphin/ContentNalbuphin.vue
+++ b/src/views/content/medications/nalbuphin/ContentNalbuphin.vue
@@ -65,7 +65,7 @@
 
     <ns-content-group title="Einsatz & Dosierung">
 
-      <ns-package :package="iv20_2"></ns-package>
+      <ns-package :package="iv_20mg"></ns-package>
 
       <ns-dosage-indication name="Schmerzen">
         <ns-dosage-usage type="iv">
@@ -74,7 +74,7 @@
           <p>Um <i>Fehldosierung</i> zu vermeiden, immer gleiche Konzentration (<text-mono>1mg/ml</text-mono>) benutzen, dazu:
           </p>
           <ns-package
-            :package="iv20_2" :inline-specs="{
+            :package="iv_20mg" :inline-specs="{
             on: 20,
             onlyOne: true }">
           </ns-package>
@@ -163,7 +163,7 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv20_2 = computed(() => props.medication.packages['iv-20mg-2ml'])
+const iv_20mg = computed(() => props.medication.packages['iv_20mg'])
 
 const onlySAA = computed(() => false) /* TODO: onlySAA-Trigger */
 

--- a/src/views/content/medications/naloxon/ContentNaloxon.vue
+++ b/src/views/content/medications/naloxon/ContentNaloxon.vue
@@ -31,7 +31,7 @@
 
     <ns-content-group title="Einsatz & Dosierung">
 
-      <ns-package :package="iv04_1"></ns-package>
+      <ns-package :package="iv_0_4mg"></ns-package>
 
       <ns-dosage-indication>
         <ns-dosage-usage type="iv">
@@ -40,7 +40,7 @@
           <p>Um <i>Fehldosierung</i> zu vermeiden, immer gleiche Konzentration (<text-mono>0,1mg/ml</text-mono>) benutzen, dazu:
           </p>
           <ns-package
-            :package="iv04_1" :inline-specs="{
+            :package="iv_0_4mg" :inline-specs="{
             on: 4, onlyOne: true }">
           </ns-package>
 
@@ -120,7 +120,7 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv04_1 = computed(() => props.medication.packages['iv-04mg-1ml'])
+const iv_0_4mg = computed(() => props.medication.packages['iv_0_4mg'])
 
 const onlySAA = computed(() => false) /* TODO: onlySAA-Trigger */
 

--- a/src/views/content/medications/paracetamol/ContentParacetamol.vue
+++ b/src/views/content/medications/paracetamol/ContentParacetamol.vue
@@ -53,13 +53,13 @@
 
     <ns-content-group title="Einsatz & Dosierung">
 
-      <ns-package :package="poTabl" v-if="isPoTablEnabled"></ns-package>
-      <ns-package :package="poSaft" v-if="isPoSaftEnabled"></ns-package>
-      <ns-package :package="supp" v-if="isSuppEnabled"></ns-package>
-      <ns-package :package="ivFlask" v-if="isIvFlaskEnabled"></ns-package>
+      <ns-package :package="po_500mg" v-if="isPo_500mgEnabled"></ns-package>
+      <ns-package :package="po_40mgml" v-if="isPo_40mgmlEnabled"></ns-package>
+      <ns-package :package="supp_125mg_250mg" v-if="isSupp_125mg_250mgEnabled"></ns-package>
+      <ns-package :package="iv_10mgml_100ml" v-if="isIv_10mgml_100mlEnabled"></ns-package>
 
       <ns-dosage-indication>
-        <ns-dosage-usage type="iv" v-if="isIvFlaskEnabled">
+        <ns-dosage-usage type="iv" v-if="isIv_10mgml_100mlEnabled">
           <h2>Kurzinfusion</h2>
           <div>
             <ns-dosage :dosage="{
@@ -75,15 +75,15 @@
           <h2>Repetition</h2>
           <p>Nur <text-underline>einmalige Gabe</text-underline> vorgesehen.</p>
         </ns-dosage-usage>
-        <ns-dosage-usage type="supp" v-if="isSuppEnabled">
+        <ns-dosage-usage type="supp" v-if="isSupp_125mg_250mgEnabled">
           <h2>Zäpfchen</h2>
           <div>
             <ns-dosage :dosage="{ target: '<2 Jahre', color: 'red', dose: ' 125mg' }"></ns-dosage>
             <ns-dosage :dosage="{ target: '>2 Jahre', color: 'green', dose: ' 250mg' }"></ns-dosage>
           </div>
         </ns-dosage-usage>
-        <ns-dosage-usage type="po" v-if="isPoTablEnabled || isPoSaftEnabled">
-          <template v-if="isPoTablEnabled">
+        <ns-dosage-usage type="po" v-if="isPo_500mgEnabled || isPo_40mgmlEnabled">
+          <template v-if="isPo_500mgEnabled">
             <h2>Tabletten</h2>
             <div>
               <ns-dosage :dosage="{
@@ -96,8 +96,8 @@
               </ns-dosage>
             </div>
           </template>
-          <hr v-if="isPoSaftEnabled && isPoTablEnabled">
-          <template v-if="isPoSaftEnabled">
+          <hr v-if="isPo_40mgmlEnabled && isPo_500mgEnabled">
+          <template v-if="isPo_40mgmlEnabled">
             <h2>Schmerzsaft</h2>
             <div>
               <ns-dosage :dosage="{ target: 'Einmaldosis', dose: ' 100mg /10kg' }"></ns-dosage>
@@ -151,22 +151,22 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const poTabl = computed(() => props.medication.packages['po-tabl'])
-const poSaft = computed(() => props.medication.packages['po-saft'])
-const supp = computed(() => props.medication.packages['supp'])
-const ivFlask = computed(() => props.medication.packages['iv-flask'])
+const po_500mg = computed(() => props.medication.packages['po_500mg'])
+const po_40mgml = computed(() => props.medication.packages['po_40mgml'])
+const supp_125mg_250mg = computed(() => props.medication.packages['supp_125mg_250mg'])
+const iv_10mgml_100ml = computed(() => props.medication.packages['iv_10mgml_100ml'])
 
-const isPoTablEnabled = computed(() => true)
-const isPoSaftEnabled = computed(() => true)
-const isSuppEnabled = computed(() => true)
-const isIvFlaskEnabled = computed(() => true)
-const onlyOneEnabled = computed(() => [ isPoTablEnabled.value, isPoSaftEnabled.value, isSuppEnabled.value, isIvFlaskEnabled.value ].filter(Boolean).length === 1)
+const isPo_500mgEnabled = computed(() => true)
+const isPo_40mgmlEnabled = computed(() => true)
+const isSupp_125mg_250mgEnabled = computed(() => true)
+const isIv_10mgml_100mlEnabled = computed(() => true)
+const onlyOneEnabled = computed(() => [ isPo_500mgEnabled.value, isPo_40mgmlEnabled.value, isSupp_125mg_250mgEnabled.value, isIv_10mgml_100mlEnabled.value ].filter(Boolean).length === 1)
 
 const onlySAA = computed(() => false) /* TODO: onlySAA-Trigger */
 
-const hasPo = computed(() => isPoTablEnabled.value || isPoSaftEnabled.value)
-const hasSupp = computed(() => isSuppEnabled.value)
-const hasIv = computed(() => isIvFlaskEnabled.value)
+const hasPo = computed(() => isPo_500mgEnabled.value || isPo_40mgmlEnabled.value)
+const hasSupp = computed(() => isSupp_125mg_250mgEnabled.value)
+const hasIv = computed(() => isIv_10mgml_100mlEnabled.value)
 
 const onsetText = computed(() => {
   const one = onlyOneEnabled.value

--- a/src/views/content/medications/prednisolon/ContentPrednisolon.vue
+++ b/src/views/content/medications/prednisolon/ContentPrednisolon.vue
@@ -29,12 +29,12 @@
 
     <ns-content-group title="Einsatz & Dosierung">
 
-      <ns-package :package="supp" v-if="isSuppEnabled"></ns-package>
-      <ns-package :package="iv100" v-if="isIv100Enabled"></ns-package>
-      <ns-package :package="iv250" v-if="isIv250Enabled"></ns-package>
+      <ns-package :package="supp_100mg" v-if="isSupp_100mgEnabled"></ns-package>
+      <ns-package :package="iv_100mg" v-if="isIv_100mgEnabled"></ns-package>
+      <ns-package :package="iv_250mg" v-if="isIv_250mgEnabled"></ns-package>
 
       <ns-dosage-indication name="Anaphylaxie">
-        <ns-dosage-usage type="supp" v-if="isSuppEnabled">
+        <ns-dosage-usage type="supp" v-if="isSupp_100mgEnabled">
           <h2>Zäpfchen</h2>
           <ns-dosage :dosage="{ type: 'child', dose: '100mg'}"></ns-dosage>
         </ns-dosage-usage>
@@ -121,26 +121,26 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const supp = computed(() => props.medication.packages['supp'])
-const iv100 = computed(() => props.medication.packages['iv-100mg'])
-const iv250 = computed(() => props.medication.packages['iv-250mg'])
+const supp_100mg = computed(() => props.medication.packages['supp_100mg'])
+const iv_100mg = computed(() => props.medication.packages['iv_100mg'])
+const iv_250mg = computed(() => props.medication.packages['iv_250mg'])
 
-const isSuppEnabled = computed(() => true)
-const isIv100Enabled = computed(() => true)
-const isIv250Enabled = computed(() => true)
-const onlyOneIvEnabled = computed(() => [ isIv100Enabled.value, isIv250Enabled.value ].filter(Boolean).length === 1)
+const isSupp_100mgEnabled = computed(() => true)
+const isIv_100mgEnabled = computed(() => true)
+const isIv_250mgEnabled = computed(() => true)
+const onlyOneIvEnabled = computed(() => [ isIv_100mgEnabled.value, isIv_250mgEnabled.value ].filter(Boolean).length === 1)
 
 const onlySAA = computed(() => false) /* TODO: onlySAA-Trigger */
 
 const ivAnalphylHintText = (amount: number) => {
   if (!onlyOneIvEnabled.value) { return '' }
-  if (isIv100Enabled.value)
+  if (isIv_100mgEnabled.value)
   {
     if (amount == 250) { return '(2½ Ampullen)' }
     if (amount == 100) { return '(1 Ampulle)' }
     if (amount == 50) { return '(½ Ampulle)' }
   }
-  if (isIv250Enabled.value)
+  if (isIv_250mgEnabled.value)
   {
     if (amount == 250) { return '(1 Ampulle)' }
     if (amount == 100) { return '(2ml)' }
@@ -151,7 +151,7 @@ const ivAnalphylHintText = (amount: number) => {
 
 
 const onsetText = computed(() => {
-  if (isSuppEnabled.value)
+  if (isSupp_100mgEnabled.value)
   {
     return '<case>i.v.</case>Ca. 5 Minuten|<case>rektal</case>Ca. 1 Stunde'
   }

--- a/src/views/content/medications/salbutamol/ContentSalbutamol.vue
+++ b/src/views/content/medications/salbutamol/ContentSalbutamol.vue
@@ -32,7 +32,7 @@
 
     <ns-content-group title="Einsatz & Dosierung">
 
-      <ns-package :package="verneb"></ns-package>
+      <ns-package :package="inh_5mgml"></ns-package>
 
       <ns-dosage-indication>
         <ns-dosage-usage type="pi">
@@ -95,7 +95,7 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const verneb = computed(() => props.medication.packages['verneb'])
+const inh_5mgml = computed(() => props.medication.packages['inh_5mgml'])
 
 const onlySAA = computed(() => false) /* TODO: onlySAA-Trigger */
 

--- a/src/views/content/medications/tranexam/ContentTranexam.vue
+++ b/src/views/content/medications/tranexam/ContentTranexam.vue
@@ -33,8 +33,8 @@
 
     <ns-content-group title="Einsatz & Dosierung">
 
-      <ns-package :package="iv100_5" v-if="isIv100_5Enabled"></ns-package>
-      <ns-package :package="iv100_10" v-if="isIv100_10Enabled"></ns-package>
+      <ns-package :package="iv_100mgml_5ml" v-if="isIv_100mgml_5mlEnabled"></ns-package>
+      <ns-package :package="iv_100mgml_10ml" v-if="isIv_100mgml_10mlEnabled"></ns-package>
 
       <ns-dosage-indication>
         <ns-dosage-usage type="iv">
@@ -88,11 +88,11 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv100_5 = computed(() => props.medication.packages['iv-500mg-5ml'])
-const iv100_10 = computed(() => props.medication.packages['iv-1000mg-10ml'])
+const iv_100mgml_5ml = computed(() => props.medication.packages['iv_100mgml_5ml'])
+const iv_100mgml_10ml = computed(() => props.medication.packages['iv_100mgml_10ml'])
 
-const isIv100_5Enabled = computed(() => true)
-const isIv100_10Enabled = computed(() => true)
+const isIv_100mgml_5mlEnabled = computed(() => true)
+const isIv_100mgml_10mlEnabled = computed(() => true)
 
 const onlySAA = computed(() => false) /* TODO: onlySAA-Trigger */
 

--- a/src/views/content/medications/urapidil/ContentUrapidil.vue
+++ b/src/views/content/medications/urapidil/ContentUrapidil.vue
@@ -54,8 +54,8 @@
 
     <ns-content-group title="Einsatz & Dosierung">
 
-      <ns-package :package="iv5_5" v-if="isIv5_5Enabled"></ns-package>
-      <ns-package :package="iv5_10" v-if="isIv5_10Enabled"></ns-package>
+      <ns-package :package="iv_5mgml_5ml" v-if="isIv_5mgml_5mlEnabled"></ns-package>
+      <ns-package :package="iv_5mgml_10ml" v-if="isIv_5mgml_10mlEnabled"></ns-package>
 
       <ns-dosage-indication>
         <ns-dosage-usage type="invisible">
@@ -124,11 +124,11 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv5_5 = computed(() => props.medication.packages['iv-5mg-ml--5ml'])
-const iv5_10 = computed(() => props.medication.packages['iv-5mg-ml--10ml'])
+const iv_5mgml_5ml = computed(() => props.medication.packages['iv_5mgml_5ml'])
+const iv_5mgml_10ml = computed(() => props.medication.packages['iv_5mgml_10ml'])
 
-const isIv5_5Enabled = computed(() => true)
-const isIv5_10Enabled = computed(() => true)
+const isIv_5mgml_5mlEnabled = computed(() => true)
+const isIv_5mgml_10mlEnabled = computed(() => true)
 
 const onlySAA = computed(() => false) /* TODO: onlySAA-Trigger */
 


### PR DESCRIPTION
## Summary
- Normalize medication package keys to the new route_concentration naming scheme with consistent unit encoding
- Update all medication content components to reference the renamed package identifiers
- Remove remaining references to legacy package keys across the codebase

## Testing
- npm test *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68dc01e09b60832eab2bc53105b925a8