### PR TITLE
Use direct medication packages in content components

### DIFF
--- a/src/views/content/medications/acetylsalicyl/ContentAcetylsalicyl.vue
+++ b/src/views/content/medications/acetylsalicyl/ContentAcetylsalicyl.vue
@@ -112,7 +112,6 @@
 
 <script setup lang="ts">
 
-import { computed } from 'vue'
 import { Medication } from '@/types/medication'
 
 import NsContentGroup from '@/components/NsContentGroup.vue'
@@ -132,7 +131,7 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv_500mg = computed(() => props.medication.packages['iv_500mg'])
+const iv_500mg = props.medication.packages['iv_500mg']
 
 </script>
 

--- a/src/views/content/medications/amiodaron/ContentAmiodaron.vue
+++ b/src/views/content/medications/amiodaron/ContentAmiodaron.vue
@@ -69,7 +69,6 @@
 
 <script setup lang="ts">
 
-import { computed } from 'vue'
 import { Medication } from '@/types/medication'
 
 import NsContentGroup from '@/components/NsContentGroup.vue'
@@ -91,7 +90,7 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv_150mg = computed(() => props.medication.packages['iv_150mg'])
+const iv_150mg = props.medication.packages['iv_150mg']
 
 </script>
 

--- a/src/views/content/medications/atropin/ContentAtropin.vue
+++ b/src/views/content/medications/atropin/ContentAtropin.vue
@@ -94,7 +94,6 @@
 
 <script setup lang="ts">
 
-import { computed } from 'vue'
 import { Medication } from '@/types/medication'
 
 import NsContentGroup from '@/components/NsContentGroup.vue'
@@ -117,7 +116,7 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv_0_5mg = computed(() => props.medication.packages['iv_0_5mg'])
+const iv_0_5mg = props.medication.packages['iv_0_5mg']
 
 </script>
 

--- a/src/views/content/medications/butylscopolamin/ContentButylscopolamin.vue
+++ b/src/views/content/medications/butylscopolamin/ContentButylscopolamin.vue
@@ -133,7 +133,6 @@
 
 <script setup lang="ts">
 
-import { computed } from 'vue'
 import { Medication } from '@/types/medication'
 
 import NsContentGroup from '@/components/NsContentGroup.vue'
@@ -156,7 +155,7 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv_20mg = computed(() => props.medication.packages['iv_20mg'])
+const iv_20mg = props.medication.packages['iv_20mg']
 
 </script>
 

--- a/src/views/content/medications/dimenhydrinat/ContentDimenhydrinat.vue
+++ b/src/views/content/medications/dimenhydrinat/ContentDimenhydrinat.vue
@@ -177,9 +177,9 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv_62mg = computed(() => props.medication.packages['iv_62mg'])
-const supp_40mg = computed(() => props.medication.packages['supp_40mg'])
-const supp_70mg = computed(() => props.medication.packages['supp_70mg'])
+const iv_62mg = props.medication.packages['iv_62mg']
+const supp_40mg = props.medication.packages['supp_40mg']
+const supp_70mg = props.medication.packages['supp_70mg']
 
 const isSupp40Enabled = computed(() => false)
 const isSupp70Enabled = computed(() => false)

--- a/src/views/content/medications/dimetinden/ContentDimetinden.vue
+++ b/src/views/content/medications/dimetinden/ContentDimetinden.vue
@@ -93,7 +93,6 @@
 
 <script setup lang="ts">
 
-import { computed } from 'vue'
 import { Medication } from '@/types/medication'
 
 import NsContentGroup from '@/components/NsContentGroup.vue'
@@ -116,7 +115,7 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv_4mg = computed(() => props.medication.packages['iv_4mg'])
+const iv_4mg = props.medication.packages['iv_4mg']
 
 </script>
 

--- a/src/views/content/medications/epinephrin/ContentEpinephrin.vue
+++ b/src/views/content/medications/epinephrin/ContentEpinephrin.vue
@@ -137,7 +137,6 @@
 
 <script setup lang="ts">
 
-import { computed } from 'vue'
 import { Medication } from '@/types/medication'
 
 import NsContentGroup from '@/components/NsContentGroup.vue'
@@ -160,7 +159,7 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv_1mg = computed(() => props.medication.packages['iv_1mg'])
+const iv_1mg = props.medication.packages['iv_1mg']
 
 </script>
 

--- a/src/views/content/medications/esketamin/ContentEsketamin.vue
+++ b/src/views/content/medications/esketamin/ContentEsketamin.vue
@@ -276,9 +276,9 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv_5mgml_5ml = computed(() => props.medication.packages['iv_5mgml_5ml'])
-const iv_25mgml_2ml = computed(() => props.medication.packages['iv_25mgml_2ml'])
-const iv_25mgml_10ml = computed(() => props.medication.packages['iv_25mgml_10ml'])
+const iv_5mgml_5ml = props.medication.packages['iv_5mgml_5ml']
+const iv_25mgml_2ml = props.medication.packages['iv_25mgml_2ml']
+const iv_25mgml_10ml = props.medication.packages['iv_25mgml_10ml']
 
 const isIv_5mgml_5mlEnabled = computed(() => true)
 const isIv_25mgml_2mlEnabled = computed(() => true)

--- a/src/views/content/medications/fentanyl/ContentFentanyl.vue
+++ b/src/views/content/medications/fentanyl/ContentFentanyl.vue
@@ -157,8 +157,8 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv_0_05mgml_2ml = computed(() => props.medication.packages['iv_0_05mgml_2ml'])
-const iv_0_05mgml_10ml = computed(() => props.medication.packages['iv_0_05mgml_10ml'])
+const iv_0_05mgml_2ml = props.medication.packages['iv_0_05mgml_2ml']
+const iv_0_05mgml_10ml = props.medication.packages['iv_0_05mgml_10ml']
 
 const isIv_0_05mgml_2mlEnabled = computed(() => true)
 const isIv_0_05mgml_10mlEnabled = computed(() => true)

--- a/src/views/content/medications/furosemid/ContentFurosemid.vue
+++ b/src/views/content/medications/furosemid/ContentFurosemid.vue
@@ -116,11 +116,15 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv_20mg = computed(() => props.medication.packages['iv_20mg'])
-const iv_40mg = computed(() => props.medication.packages['iv_40mg'])
+const iv_20mg = props.medication.packages['iv_20mg']
+const iv_40mg = props.medication.packages['iv_40mg']
+const iv20mg = iv_20mg
+const iv40mg = iv_40mg
 
 const isIv_20mgEnabled = computed(() => true)
 const isIv_40mgEnabled = computed(() => true)
+const isIv20mgEnabled = isIv_20mgEnabled
+const isIv40mgEnabled = isIv_40mgEnabled
 const onlyOneEnabled = computed(() => [ isIv_20mgEnabled.value, isIv_40mgEnabled.value ].filter(Boolean).length === 1)
 
 const onlySAA = computed(() => false) /* TODO: onlySAA-Trigger */

--- a/src/views/content/medications/glucagon/ContentGlucagon.vue
+++ b/src/views/content/medications/glucagon/ContentGlucagon.vue
@@ -115,8 +115,8 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const im_1mg = computed(() => props.medication.packages['im_1mg'])
-const nasal_3mg = computed(() => props.medication.packages['nasal_3mg'])
+const im_1mg = props.medication.packages['im_1mg']
+const nasal_3mg = props.medication.packages['nasal_3mg']
 
 const isIm_1mgEnabled = computed(() => true)
 const isNasal_3mgEnabled = computed(() => true)

--- a/src/views/content/medications/glucose/ContentGlucose.vue
+++ b/src/views/content/medications/glucose/ContentGlucose.vue
@@ -94,9 +94,9 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv_1g_10ml = computed(() => props.medication.packages['iv_1g_10ml'])
-const iv_2g_10ml = computed(() => props.medication.packages['iv_2g_10ml'])
-const iv_4g_10ml = computed(() => props.medication.packages['iv_4g_10ml'])
+const iv_1g_10ml = props.medication.packages['iv_1g_10ml']
+const iv_2g_10ml = props.medication.packages['iv_2g_10ml']
+const iv_4g_10ml = props.medication.packages['iv_4g_10ml']
 
 const isIv_1g_10mlEnabled = computed(() => true)
 const isIv_2g_10mlEnabled = computed(() => true)

--- a/src/views/content/medications/glyceroltrinitrat/ContentGlyceroltrinitrat.vue
+++ b/src/views/content/medications/glyceroltrinitrat/ContentGlyceroltrinitrat.vue
@@ -131,7 +131,7 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const spray_0_4mg = computed(() => props.medication.packages['spray_0_4mg'])
+const spray_0_4mg = props.medication.packages['spray_0_4mg']
 
 const onlySAA = computed(() => false) /* TODO: onlySAA-Trigger */
 

--- a/src/views/content/medications/heparin/ContentHeparin.vue
+++ b/src/views/content/medications/heparin/ContentHeparin.vue
@@ -113,9 +113,9 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv_25000ieml_0_2ml = computed(() => props.medication.packages['iv_25000ieml_0_2ml'])
-const iv_5000ieml_5ml = computed(() => props.medication.packages['iv_5000ieml_5ml'])
-const iv_5000ieml_1ml = computed(() => props.medication.packages['iv_5000ieml_1ml'])
+const iv_25000ieml_0_2ml = props.medication.packages['iv_25000ieml_0_2ml']
+const iv_5000ieml_5ml = props.medication.packages['iv_5000ieml_5ml']
+const iv_5000ieml_1ml = props.medication.packages['iv_5000ieml_1ml']
 
 const isIv_25000ieml_0_2mlEnabled = computed(() => false)
 const isIv_5000ieml_5mlEnabled = computed(() => true)

--- a/src/views/content/medications/ibuprofen/ContentIbuprofen.vue
+++ b/src/views/content/medications/ibuprofen/ContentIbuprofen.vue
@@ -150,10 +150,10 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const po_200mg_400mg_600mg_800mg = computed(() => props.medication.packages['po_200mg_400mg_600mg_800mg'])
-const po_20mgml_40mgml = computed(() => props.medication.packages['po_20mgml_40mgml'])
-const supp_75mg_125mg_150mg_250mg = computed(() => props.medication.packages['supp_75mg_125mg_150mg_250mg'])
-const iv_4mgml_6mgml_100ml = computed(() => props.medication.packages['iv_4mgml_6mgml_100ml'])
+const po_200mg_400mg_600mg_800mg = props.medication.packages['po_200mg_400mg_600mg_800mg']
+const po_20mgml_40mgml = props.medication.packages['po_20mgml_40mgml']
+const supp_75mg_125mg_150mg_250mg = props.medication.packages['supp_75mg_125mg_150mg_250mg']
+const iv_4mgml_6mgml_100ml = props.medication.packages['iv_4mgml_6mgml_100ml']
 
 const isPo_200mg_400mg_600mg_800mgEnabled = computed(() => true)
 const isPo_20mgml_40mgmlEnabled = computed(() => true)

--- a/src/views/content/medications/ipratropiumbromid/ContentIpratropiumbromid.vue
+++ b/src/views/content/medications/ipratropiumbromid/ContentIpratropiumbromid.vue
@@ -130,8 +130,8 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const inh_250ug = computed(() => props.medication.packages['inh_250ug'])
-const inh_500ug = computed(() => props.medication.packages['inh_500ug'])
+const inh_250ug = props.medication.packages['inh_250ug']
+const inh_500ug = props.medication.packages['inh_500ug']
 
 const isInh_250ugEnabled = computed(() => false)
 const isInh_500ugEnabled = computed(() => true)

--- a/src/views/content/medications/metoprolol/ContentMetoprolol.vue
+++ b/src/views/content/medications/metoprolol/ContentMetoprolol.vue
@@ -125,7 +125,7 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv_5mg = computed(() => props.medication.packages['iv_5mg'])
+const iv_5mg = props.medication.packages['iv_5mg']
 
 const onlySAA = computed(() => false) /* TODO: onlySAA-Trigger */
 

--- a/src/views/content/medications/midazolam/ContentMidazolam.vue
+++ b/src/views/content/medications/midazolam/ContentMidazolam.vue
@@ -236,10 +236,10 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv_5mgml_1ml = computed(() => props.medication.packages['iv_5mgml_1ml'])
-const iv_5mgml_3ml = computed(() => props.medication.packages['iv_5mgml_3ml'])
-const iv_1mgml_5ml = computed(() => props.medication.packages['iv_1mgml_5ml'])
-const buccal_2_5mg_5mg_7_5mg_10mg = computed(() => props.medication.packages['buccal_2_5mg_5mg_7_5mg_10mg'])
+const iv_5mgml_1ml = props.medication.packages['iv_5mgml_1ml']
+const iv_5mgml_3ml = props.medication.packages['iv_5mgml_3ml']
+const iv_1mgml_5ml = props.medication.packages['iv_1mgml_5ml']
+const buccal_2_5mg_5mg_7_5mg_10mg = props.medication.packages['buccal_2_5mg_5mg_7_5mg_10mg']
 
 const isIv_5mgml_1mlEnabled = computed(() => true)
 const isIv_5mgml_3mlEnabled = computed(() => true)

--- a/src/views/content/medications/morphin/ContentMorphin.vue
+++ b/src/views/content/medications/morphin/ContentMorphin.vue
@@ -145,8 +145,8 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv_10mg = computed(() => props.medication.packages['iv_10mg'])
-const iv_20mg = computed(() => props.medication.packages['iv_20mg'])
+const iv_10mg = props.medication.packages['iv_10mg']
+const iv_20mg = props.medication.packages['iv_20mg']
 
 const isIv_10mgEnabled = computed(() => true)
 const isIv_20mgEnabled = computed(() => true)

--- a/src/views/content/medications/nalbuphin/ContentNalbuphin.vue
+++ b/src/views/content/medications/nalbuphin/ContentNalbuphin.vue
@@ -163,7 +163,7 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv_20mg = computed(() => props.medication.packages['iv_20mg'])
+const iv_20mg = props.medication.packages['iv_20mg']
 
 const onlySAA = computed(() => false) /* TODO: onlySAA-Trigger */
 

--- a/src/views/content/medications/naloxon/ContentNaloxon.vue
+++ b/src/views/content/medications/naloxon/ContentNaloxon.vue
@@ -120,7 +120,7 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv_0_4mg = computed(() => props.medication.packages['iv_0_4mg'])
+const iv_0_4mg = props.medication.packages['iv_0_4mg']
 
 const onlySAA = computed(() => false) /* TODO: onlySAA-Trigger */
 

--- a/src/views/content/medications/paracetamol/ContentParacetamol.vue
+++ b/src/views/content/medications/paracetamol/ContentParacetamol.vue
@@ -151,10 +151,10 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const po_500mg = computed(() => props.medication.packages['po_500mg'])
-const po_40mgml = computed(() => props.medication.packages['po_40mgml'])
-const supp_125mg_250mg = computed(() => props.medication.packages['supp_125mg_250mg'])
-const iv_10mgml_100ml = computed(() => props.medication.packages['iv_10mgml_100ml'])
+const po_500mg = props.medication.packages['po_500mg']
+const po_40mgml = props.medication.packages['po_40mgml']
+const supp_125mg_250mg = props.medication.packages['supp_125mg_250mg']
+const iv_10mgml_100ml = props.medication.packages['iv_10mgml_100ml']
 
 const isPo_500mgEnabled = computed(() => true)
 const isPo_40mgmlEnabled = computed(() => true)

--- a/src/views/content/medications/prednisolon/ContentPrednisolon.vue
+++ b/src/views/content/medications/prednisolon/ContentPrednisolon.vue
@@ -121,9 +121,9 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const supp_100mg = computed(() => props.medication.packages['supp_100mg'])
-const iv_100mg = computed(() => props.medication.packages['iv_100mg'])
-const iv_250mg = computed(() => props.medication.packages['iv_250mg'])
+const supp_100mg = props.medication.packages['supp_100mg']
+const iv_100mg = props.medication.packages['iv_100mg']
+const iv_250mg = props.medication.packages['iv_250mg']
 
 const isSupp_100mgEnabled = computed(() => true)
 const isIv_100mgEnabled = computed(() => true)

--- a/src/views/content/medications/salbutamol/ContentSalbutamol.vue
+++ b/src/views/content/medications/salbutamol/ContentSalbutamol.vue
@@ -95,7 +95,7 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const inh_5mgml = computed(() => props.medication.packages['inh_5mgml'])
+const inh_5mgml = props.medication.packages['inh_5mgml']
 
 const onlySAA = computed(() => false) /* TODO: onlySAA-Trigger */
 

--- a/src/views/content/medications/tranexam/ContentTranexam.vue
+++ b/src/views/content/medications/tranexam/ContentTranexam.vue
@@ -88,8 +88,8 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv_100mgml_5ml = computed(() => props.medication.packages['iv_100mgml_5ml'])
-const iv_100mgml_10ml = computed(() => props.medication.packages['iv_100mgml_10ml'])
+const iv_100mgml_5ml = props.medication.packages['iv_100mgml_5ml']
+const iv_100mgml_10ml = props.medication.packages['iv_100mgml_10ml']
 
 const isIv_100mgml_5mlEnabled = computed(() => true)
 const isIv_100mgml_10mlEnabled = computed(() => true)

--- a/src/views/content/medications/urapidil/ContentUrapidil.vue
+++ b/src/views/content/medications/urapidil/ContentUrapidil.vue
@@ -124,8 +124,8 @@ const props = defineProps<{
   medication: Medication,
 }>()
 
-const iv_5mgml_5ml = computed(() => props.medication.packages['iv_5mgml_5ml'])
-const iv_5mgml_10ml = computed(() => props.medication.packages['iv_5mgml_10ml'])
+const iv_5mgml_5ml = props.medication.packages['iv_5mgml_5ml']
+const iv_5mgml_10ml = props.medication.packages['iv_5mgml_10ml']
 
 const isIv_5mgml_5mlEnabled = computed(() => true)
 const isIv_5mgml_10mlEnabled = computed(() => true)


### PR DESCRIPTION
## Summary
- replace computed package references with direct constant assignments across medication content components
- remove unused `computed` imports and add helper aliases where templates expect alternate names

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcf86cfc74832ebf0bfcdb5ebdb38f