### PR TITLE
refactor: handle flow navigation in NsFlow

### DIFF
--- a/src/views/content/library/bpr/atemwegsmanagement/ContentAtemwegsmanagement.vue
+++ b/src/views/content/library/bpr/atemwegsmanagement/ContentAtemwegsmanagement.vue
@@ -1,69 +1,19 @@
 <template>
   <div id="ns-content-bg" class="flow-page">
-    <NsFlow
-      class="flow-surface"
-      :svg-markup="svgMarkup"
-      @link-activate="onFlowLinkActivate"
-    />
+    <NsFlow class="flow-surface" :svg-markup="svgMarkup" @action="handleAction" />
   </div>
 </template>
 
 <script setup lang="ts">
-import { useRouter } from 'vue-router'
 import NsFlow from '@/components/library/NsFlow.vue'
 import flowSvg from './flow.svg?raw'
 
-const router = useRouter()
 const svgMarkup = flowSvg
-
-interface FlowLinkActivatePayload {
-  href: string | null
-  element: Element
-  event: Event
-}
 
 function handleAction(key: string) {
   // Placeholder for action handling logic
   // Integrate with actual business logic when available
   console.debug('[ContentAtemwegsmanagement] handleAction', key)
-}
-
-function normalizeHref(rawHref: string): URL | null {
-  if (!rawHref) {
-    return null
-  }
-
-  let href = rawHref.trim()
-  if (href.startsWith('file:///')) {
-    href = href.slice('file://'.length)
-  }
-  if (!href.startsWith('/')) {
-    href = `/${href.replace(/^\/*/, '')}`
-  }
-
-  try {
-    return new URL(href, 'https://local.app')
-  } catch (error) {
-    console.warn('Invalid link in flow diagram', rawHref)
-    return null
-  }
-}
-
-function onFlowLinkActivate(payload: FlowLinkActivatePayload) {
-  const url = payload.href ? normalizeHref(payload.href) : null
-
-  if (!url) {
-    return
-  }
-
-  const action = url.searchParams.get('action')
-  if (url.pathname) {
-    router.push(`${url.pathname}${url.search}`)
-  }
-
-  if (action) {
-    handleAction(action)
-  }
 }
 </script>
 


### PR DESCRIPTION
## Summary
- handle flow link routing inside NsFlow while emitting action events
- simplify the Atemwegsmanagement content view to respond to action events only

## Testing
- npm run build *(fails: existing TypeScript error for acetylsalicyl content component)*

------
https://chatgpt.com/codex/tasks/task_e_68dd6daa3e14832e9a8b625266c6ef41