### PR TITLE
Fix floating point rounding output

### DIFF
--- a/src/service/math.ts
+++ b/src/service/math.ts
@@ -12,14 +12,36 @@ export function round(value: number, multiple: number, direction?: 'up' | 'down'
   if (multiple === 0) return value; // avoid division by zero
   const quotient = value / multiple;
 
-  switch (direction) {
-    case 'up':
-      return Math.ceil(quotient) * multiple;
-    case 'down':
-      return Math.floor(quotient) * multiple;
-    default:
-      return Math.round(quotient) * multiple;
+  const result = (() => {
+    switch (direction) {
+      case 'up':
+        return Math.ceil(quotient) * multiple;
+      case 'down':
+        return Math.floor(quotient) * multiple;
+      default:
+        return Math.round(quotient) * multiple;
+    }
+  })();
+
+  const precision = Math.max(decimalPlaces(value), decimalPlaces(multiple));
+  return sanitizeFloatingPoint(result, precision);
+}
+
+function decimalPlaces(num: number): number {
+  if (!Number.isFinite(num)) return 0;
+  const [coefficient, exponent = '0'] = num.toString().split(/[eE]/);
+  const fraction = coefficient.split('.')[1] ?? '';
+  const adjustment = Number.parseInt(exponent, 10);
+  return Math.max(0, fraction.length - adjustment);
+}
+
+function sanitizeFloatingPoint(num: number, precision: number): number {
+  if (precision <= 0) {
+    return Math.round(num + Number.EPSILON);
   }
+  const safePrecision = Math.min(precision, 15);
+  const factor = 10 ** safePrecision;
+  return Math.round((num + Number.EPSILON) * factor) / factor;
 }
 
 /**


### PR DESCRIPTION
## Summary
- sanitize the math service round helper to avoid floating point artifacts when rounding to multiples
- add decimal precision utilities to normalize integer and decimal results consistently

## Testing
- npm run test:unit -- --run *(fails: Failed to resolve import "@/views/Tab1Page.vue" in existing test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68e28282b610832e81da920fb6946d59