### PR TITLE
Fix rounding helper floating-point artifacts

### DIFF
--- a/src/service/math.ts
+++ b/src/service/math.ts
@@ -36,12 +36,12 @@ function decimalPlaces(num: number): number {
 }
 
 function sanitizeFloatingPoint(num: number, precision: number): number {
-  if (precision <= 0) {
-    return Math.round(num + Number.EPSILON);
+  if (!Number.isFinite(num)) {
+    return num;
   }
-  const safePrecision = Math.min(precision, 15);
-  const factor = 10 ** safePrecision;
-  return Math.round((num + Number.EPSILON) * factor) / factor;
+
+  const safePrecision = Math.min(Math.max(precision, 0), 15);
+  return Number.parseFloat(num.toFixed(safePrecision));
 }
 
 /**


### PR DESCRIPTION
## Summary
- sanitize rounded results using `toFixed` to eliminate lingering floating point residues
- guard rounding sanitizer against non-finite inputs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2838047bc832eb1dbc4f8fe5b5e12