### PR TITLE
Refactor medication package flags into composable

### DIFF
--- a/src/composables/useMedicationPackageFlags.ts
+++ b/src/composables/useMedicationPackageFlags.ts
@@ -1,0 +1,18 @@
+import { computed, type ComputedRef } from 'vue'
+import { useConfigStore } from '@/stores/config'
+
+export function useMedicationPackageFlags<const Keys extends readonly string[]>(
+  medicationId: string,
+  packageIds: Keys,
+): { [K in Keys[number]]: ComputedRef<boolean> } {
+  const configStore = useConfigStore()
+
+  const flags = {} as { [K in Keys[number]]: ComputedRef<boolean> }
+
+  for (const packageId of packageIds) {
+    const key = packageId as Keys[number]
+    flags[key] = computed(() => configStore.checkPackageEnable(medicationId, key))
+  }
+
+  return flags
+}

--- a/src/views/content/medications/dimenhydrinat/ContentDimenhydrinat.vue
+++ b/src/views/content/medications/dimenhydrinat/ContentDimenhydrinat.vue
@@ -162,16 +162,10 @@ import TextUnderline from '@/components/TextUnderline.vue'
 
 import imgLongQt from '@/data/assets/long-qt.png'
 
-import { iv_62mg, supp_40mg, supp_70mg } from './Packages'
-import { MedId } from '@/types/medication'
-import { useConfigStore } from '@/stores/config'
-const configStore = useConfigStore()
+import { iv_62mg, supp_40mg, supp_70mg, isIv_62Enabled, isSupp40Enabled, isSupp70Enabled } from './Packages'
 
 // ########################################################################################################
 
-const isIv_62Enabled = computed(() => configStore.checkPackageEnable(MedId.Dimenhydrinat, iv_62mg.id))
-const isSupp40Enabled = computed(() => configStore.checkPackageEnable(MedId.Dimenhydrinat, supp_40mg.id))
-const isSupp70Enabled = computed(() => configStore.checkPackageEnable(MedId.Dimenhydrinat, supp_70mg.id))
 const anySuppEnabled = computed(() => isSupp40Enabled.value || isSupp70Enabled.value)
 
 </script>

--- a/src/views/content/medications/dimenhydrinat/Packages.ts
+++ b/src/views/content/medications/dimenhydrinat/Packages.ts
@@ -1,11 +1,20 @@
+import { useMedicationPackageFlags } from '@/composables/useMedicationPackageFlags'
+import { MedId } from '@/types/medication'
 import { resolvePackages } from '../resolvePackages'
 
-const packages = resolvePackages('dimenhydrinat', [
+const packageIds = [
   'iv_62mg',
   'supp_40mg',
   'supp_70mg'
-] as const)
+] as const
+
+const packages = resolvePackages('dimenhydrinat', packageIds)
+const packageFlags = useMedicationPackageFlags(MedId.Dimenhydrinat, packageIds)
 
 export const iv_62mg = packages.iv_62mg
 export const supp_40mg = packages.supp_40mg
 export const supp_70mg = packages.supp_70mg
+
+export const isIv_62Enabled = packageFlags.iv_62mg
+export const isSupp40Enabled = packageFlags.supp_40mg
+export const isSupp70Enabled = packageFlags.supp_70mg

--- a/src/views/content/medications/esketamin/ContentEsketamin.vue
+++ b/src/views/content/medications/esketamin/ContentEsketamin.vue
@@ -270,16 +270,16 @@ import TextUnderline from '@/components/TextUnderline.vue'
 import imgLongQt from '@/data/assets/long-qt.png'
 import { arrowForwardOutline } from 'ionicons/icons'
 
-import { iv_5mgml_5ml, iv_25mgml_2ml, iv_25mgml_10ml } from './Packages'
-import { MedId } from '@/types/medication'
-import { useConfigStore } from '@/stores/config'
-const configStore = useConfigStore()
+import {
+  iv_5mgml_5ml,
+  iv_25mgml_2ml,
+  iv_25mgml_10ml,
+  isIv_5mgml_5mlEnabled,
+  isIv_25mgml_2mlEnabled,
+  isIv_25mgml_10mlEnabled,
+} from './Packages'
 
 // ########################################################################################################
-
-const isIv_5mgml_5mlEnabled = computed(() => configStore.checkPackageEnable(MedId.Esketamin, iv_5mgml_5ml.id))
-const isIv_25mgml_2mlEnabled = computed(() => configStore.checkPackageEnable(MedId.Esketamin, iv_25mgml_2ml.id))
-const isIv_25mgml_10mlEnabled = computed(() => configStore.checkPackageEnable(MedId.Esketamin, iv_25mgml_10ml.id))
 
 const onlyOneEnabled = computed(() => [ isIv_5mgml_5mlEnabled.value, isIv_25mgml_2mlEnabled.value, isIv_25mgml_10mlEnabled.value ].filter(Boolean).length === 1)
 

--- a/src/views/content/medications/esketamin/Packages.ts
+++ b/src/views/content/medications/esketamin/Packages.ts
@@ -1,11 +1,20 @@
+import { useMedicationPackageFlags } from '@/composables/useMedicationPackageFlags'
+import { MedId } from '@/types/medication'
 import { resolvePackages } from '../resolvePackages'
 
-const packages = resolvePackages('esketamin', [
+const packageIds = [
   'iv_5mgml_5ml',
   'iv_25mgml_2ml',
   'iv_25mgml_10ml'
-] as const)
+] as const
+
+const packages = resolvePackages('esketamin', packageIds)
+const packageFlags = useMedicationPackageFlags(MedId.Esketamin, packageIds)
 
 export const iv_5mgml_5ml = packages.iv_5mgml_5ml
 export const iv_25mgml_2ml = packages.iv_25mgml_2ml
 export const iv_25mgml_10ml = packages.iv_25mgml_10ml
+
+export const isIv_5mgml_5mlEnabled = packageFlags.iv_5mgml_5ml
+export const isIv_25mgml_2mlEnabled = packageFlags.iv_25mgml_2ml
+export const isIv_25mgml_10mlEnabled = packageFlags.iv_25mgml_10ml

--- a/src/views/content/medications/fentanyl/ContentFentanyl.vue
+++ b/src/views/content/medications/fentanyl/ContentFentanyl.vue
@@ -151,15 +151,9 @@ import NsPharmacodynamics from '@/components/medications/NsPharmacodynamics.vue'
 import TextMono from '@/components/TextMono.vue'
 import TextUnderline from '@/components/TextUnderline.vue'
 
-import { iv_0_05mgml_2ml, iv_0_05mgml_10ml } from './Packages'
-import { MedId } from '@/types/medication'
-import { useConfigStore } from '@/stores/config'
-const configStore = useConfigStore()
+import { iv_0_05mgml_2ml, iv_0_05mgml_10ml, isIv_0_05mgml_2mlEnabled, isIv_0_05mgml_10mlEnabled } from './Packages'
 
 // ########################################################################################################
-
-const isIv_0_05mgml_2mlEnabled = computed(() => configStore.checkPackageEnable(MedId.Fentanyl, iv_0_05mgml_2ml.id))
-const isIv_0_05mgml_10mlEnabled = computed(() => configStore.checkPackageEnable(MedId.Fentanyl, iv_0_05mgml_10ml.id))
 
 // ########################################################################################################
 

--- a/src/views/content/medications/fentanyl/Packages.ts
+++ b/src/views/content/medications/fentanyl/Packages.ts
@@ -1,9 +1,17 @@
+import { useMedicationPackageFlags } from '@/composables/useMedicationPackageFlags'
+import { MedId } from '@/types/medication'
 import { resolvePackages } from '../resolvePackages'
 
-const packages = resolvePackages('fentanyl', [
+const packageIds = [
   'iv_0_05mgml_2ml',
   'iv_0_05mgml_10ml'
-] as const)
+] as const
+
+const packages = resolvePackages('fentanyl', packageIds)
+const packageFlags = useMedicationPackageFlags(MedId.Fentanyl, packageIds)
 
 export const iv_0_05mgml_2ml = packages.iv_0_05mgml_2ml
 export const iv_0_05mgml_10ml = packages.iv_0_05mgml_10ml
+
+export const isIv_0_05mgml_2mlEnabled = packageFlags.iv_0_05mgml_2ml
+export const isIv_0_05mgml_10mlEnabled = packageFlags.iv_0_05mgml_10ml

--- a/src/views/content/medications/furosemid/ContentFurosemid.vue
+++ b/src/views/content/medications/furosemid/ContentFurosemid.vue
@@ -110,15 +110,9 @@ import NsPharmacodynamics from '@/components/medications/NsPharmacodynamics.vue'
 import TextMono from '@/components/TextMono.vue'
 import TextUnderline from '@/components/TextUnderline.vue'
 
-import { iv_20mg, iv_40mg } from './Packages'
-import { MedId } from '@/types/medication'
-import { useConfigStore } from '@/stores/config'
-const configStore = useConfigStore()
+import { iv_20mg, iv_40mg, isIv_20mgEnabled, isIv_40mgEnabled } from './Packages'
 
 // ########################################################################################################
-
-const isIv_20mgEnabled = computed(() => configStore.checkPackageEnable(MedId.Furosemid, iv_20mg.id))
-const isIv_40mgEnabled = computed(() => configStore.checkPackageEnable(MedId.Furosemid, iv_40mg.id))
 
 const onlyOneEnabled = computed(() => [ isIv_20mgEnabled.value, isIv_40mgEnabled.value ].filter(Boolean).length === 1)
 

--- a/src/views/content/medications/furosemid/Packages.ts
+++ b/src/views/content/medications/furosemid/Packages.ts
@@ -1,6 +1,14 @@
+import { useMedicationPackageFlags } from '@/composables/useMedicationPackageFlags'
+import { MedId } from '@/types/medication'
 import { resolvePackages } from '../resolvePackages'
 
-const packages = resolvePackages('furosemid', ['iv_20mg', 'iv_40mg'] as const)
+const packageIds = ['iv_20mg', 'iv_40mg'] as const
+
+const packages = resolvePackages('furosemid', packageIds)
+const packageFlags = useMedicationPackageFlags(MedId.Furosemid, packageIds)
 
 export const iv_20mg = packages.iv_20mg
 export const iv_40mg = packages.iv_40mg
+
+export const isIv_20mgEnabled = packageFlags.iv_20mg
+export const isIv_40mgEnabled = packageFlags.iv_40mg

--- a/src/views/content/medications/glucagon/ContentGlucagon.vue
+++ b/src/views/content/medications/glucagon/ContentGlucagon.vue
@@ -109,15 +109,9 @@ import NsPharmacodynamics from '@/components/medications/NsPharmacodynamics.vue'
 import TextMono from '@/components/TextMono.vue'
 import TextUnderline from '@/components/TextUnderline.vue'
 
-import { im_1mg, nasal_3mg } from './Packages'
-import { MedId } from '@/types/medication'
-import { useConfigStore } from '@/stores/config'
-const configStore = useConfigStore()
+import { im_1mg, nasal_3mg, isIm_1mgEnabled, isNasal_3mgEnabled } from './Packages'
 
 // ########################################################################################################
-
-const isIm_1mgEnabled = computed(() => configStore.checkPackageEnable(MedId.Glucagon, im_1mg.id))
-const isNasal_3mgEnabled = computed(() => configStore.checkPackageEnable(MedId.Glucagon, nasal_3mg.id))
 
 const onlyOneEnabled = computed(() => [ isIm_1mgEnabled.value, isNasal_3mgEnabled.value ].filter(Boolean).length === 1)
 

--- a/src/views/content/medications/glucagon/Packages.ts
+++ b/src/views/content/medications/glucagon/Packages.ts
@@ -1,9 +1,17 @@
+import { useMedicationPackageFlags } from '@/composables/useMedicationPackageFlags'
+import { MedId } from '@/types/medication'
 import { resolvePackages } from '../resolvePackages'
 
-const packages = resolvePackages('glucagon', [
+const packageIds = [
   'im_1mg',
   'nasal_3mg'
-] as const)
+] as const
+
+const packages = resolvePackages('glucagon', packageIds)
+const packageFlags = useMedicationPackageFlags(MedId.Glucagon, packageIds)
 
 export const im_1mg = packages.im_1mg
 export const nasal_3mg = packages.nasal_3mg
+
+export const isIm_1mgEnabled = packageFlags.im_1mg
+export const isNasal_3mgEnabled = packageFlags.nasal_3mg

--- a/src/views/content/medications/glucose/ContentGlucose.vue
+++ b/src/views/content/medications/glucose/ContentGlucose.vue
@@ -88,16 +88,9 @@ import NsPharmacodynamics from '@/components/medications/NsPharmacodynamics.vue'
 import TextMono from '@/components/TextMono.vue'
 import TextUnderline from '@/components/TextUnderline.vue'
 
-import { iv_1g_10ml, iv_2g_10ml, iv_4g_10ml } from './Packages'
-import { MedId } from '@/types/medication'
-import { useConfigStore } from '@/stores/config'
-const configStore = useConfigStore()
+import { iv_1g_10ml, iv_2g_10ml, iv_4g_10ml, isIv_1g_10mlEnabled, isIv_2g_10mlEnabled, isIv_4g_10mlEnabled } from './Packages'
 
 // ########################################################################################################
-
-const isIv_1g_10mlEnabled = computed(() => configStore.checkPackageEnable(MedId.Glucose, iv_1g_10ml.id))
-const isIv_2g_10mlEnabled = computed(() => configStore.checkPackageEnable(MedId.Glucose, iv_2g_10ml.id))
-const isIv_4g_10mlEnabled = computed(() => configStore.checkPackageEnable(MedId.Glucose, iv_4g_10ml.id))
 
 const onlyOneEnabled = computed(() => [ isIv_1g_10mlEnabled.value, isIv_2g_10mlEnabled.value, isIv_4g_10mlEnabled.value ].filter(Boolean).length === 1)
 

--- a/src/views/content/medications/glucose/Packages.ts
+++ b/src/views/content/medications/glucose/Packages.ts
@@ -1,11 +1,20 @@
+import { useMedicationPackageFlags } from '@/composables/useMedicationPackageFlags'
+import { MedId } from '@/types/medication'
 import { resolvePackages } from '../resolvePackages'
 
-const packages = resolvePackages('glucose', [
+const packageIds = [
   'iv_1g_10ml',
   'iv_2g_10ml',
   'iv_4g_10ml'
-] as const)
+] as const
+
+const packages = resolvePackages('glucose', packageIds)
+const packageFlags = useMedicationPackageFlags(MedId.Glucose, packageIds)
 
 export const iv_1g_10ml = packages.iv_1g_10ml
 export const iv_2g_10ml = packages.iv_2g_10ml
 export const iv_4g_10ml = packages.iv_4g_10ml
+
+export const isIv_1g_10mlEnabled = packageFlags.iv_1g_10ml
+export const isIv_2g_10mlEnabled = packageFlags.iv_2g_10ml
+export const isIv_4g_10mlEnabled = packageFlags.iv_4g_10ml

--- a/src/views/content/medications/heparin/ContentHeparin.vue
+++ b/src/views/content/medications/heparin/ContentHeparin.vue
@@ -107,16 +107,16 @@ import NsPharmacodynamics from '@/components/medications/NsPharmacodynamics.vue'
 import TextMono from '@/components/TextMono.vue'
 import TextUnderline from '@/components/TextUnderline.vue'
 
-import { iv_25000ieml_0_2ml, iv_5000ieml_5ml, iv_5000ieml_1ml } from './Packages'
-import { MedId } from '@/types/medication'
-import { useConfigStore } from '@/stores/config'
-const configStore = useConfigStore()
+import {
+  iv_25000ieml_0_2ml,
+  iv_5000ieml_5ml,
+  iv_5000ieml_1ml,
+  isIv_25000ieml_0_2mlEnabled,
+  isIv_5000ieml_5mlEnabled,
+  isIv_5000ieml_1mlEnabled,
+} from './Packages'
 
 // ########################################################################################################
-
-const isIv_25000ieml_0_2mlEnabled = computed(() => configStore.checkPackageEnable(MedId.Heparin, iv_25000ieml_0_2ml.id))
-const isIv_5000ieml_5mlEnabled = computed(() => configStore.checkPackageEnable(MedId.Heparin, iv_5000ieml_5ml.id))
-const isIv_5000ieml_1mlEnabled = computed(() => configStore.checkPackageEnable(MedId.Heparin, iv_5000ieml_1ml.id))
 
 const onlyOneEnabled = computed(() => [ isIv_25000ieml_0_2mlEnabled.value, isIv_5000ieml_5mlEnabled.value, isIv_5000ieml_1mlEnabled.value ].filter(Boolean).length === 1)
 

--- a/src/views/content/medications/heparin/Packages.ts
+++ b/src/views/content/medications/heparin/Packages.ts
@@ -1,11 +1,20 @@
+import { useMedicationPackageFlags } from '@/composables/useMedicationPackageFlags'
+import { MedId } from '@/types/medication'
 import { resolvePackages } from '../resolvePackages'
 
-const packages = resolvePackages('heparin', [
+const packageIds = [
   'iv_25000ieml_0_2ml',
   'iv_5000ieml_5ml',
   'iv_5000ieml_1ml'
-] as const)
+] as const
+
+const packages = resolvePackages('heparin', packageIds)
+const packageFlags = useMedicationPackageFlags(MedId.Heparin, packageIds)
 
 export const iv_25000ieml_0_2ml = packages.iv_25000ieml_0_2ml
 export const iv_5000ieml_5ml = packages.iv_5000ieml_5ml
 export const iv_5000ieml_1ml = packages.iv_5000ieml_1ml
+
+export const isIv_25000ieml_0_2mlEnabled = packageFlags.iv_25000ieml_0_2ml
+export const isIv_5000ieml_5mlEnabled = packageFlags.iv_5000ieml_5ml
+export const isIv_5000ieml_1mlEnabled = packageFlags.iv_5000ieml_1ml

--- a/src/views/content/medications/ibuprofen/ContentIbuprofen.vue
+++ b/src/views/content/medications/ibuprofen/ContentIbuprofen.vue
@@ -144,17 +144,18 @@ import NsPharmacodynamics from '@/components/medications/NsPharmacodynamics.vue'
 import TextMono from '@/components/TextMono.vue'
 import TextUnderline from '@/components/TextUnderline.vue'
 
-import { po_200mg_400mg_600mg_800mg, po_20mgml_40mgml, supp_75mg_125mg_150mg_250mg, iv_4mgml_6mgml_100ml } from './Packages'
-import { MedId } from '@/types/medication'
-import { useConfigStore } from '@/stores/config'
-const configStore = useConfigStore()
+import {
+  po_200mg_400mg_600mg_800mg,
+  po_20mgml_40mgml,
+  supp_75mg_125mg_150mg_250mg,
+  iv_4mgml_6mgml_100ml,
+  isPo_200mg_400mg_600mg_800mgEnabled,
+  isPo_20mgml_40mgmlEnabled,
+  isSupp_75mg_125mg_150mg_250mgEnabled,
+  isIv_4mgml_6mgml_100mlEnabled,
+} from './Packages'
 
 // ########################################################################################################
-
-const isPo_200mg_400mg_600mg_800mgEnabled = computed(() => configStore.checkPackageEnable(MedId.Ibuprofen, po_200mg_400mg_600mg_800mg.id))
-const isPo_20mgml_40mgmlEnabled = computed(() => configStore.checkPackageEnable(MedId.Ibuprofen, po_20mgml_40mgml.id))
-const isSupp_75mg_125mg_150mg_250mgEnabled = computed(() => configStore.checkPackageEnable(MedId.Ibuprofen, supp_75mg_125mg_150mg_250mg.id))
-const isIv_4mgml_6mgml_100mlEnabled = computed(() => configStore.checkPackageEnable(MedId.Ibuprofen, iv_4mgml_6mgml_100ml.id))
 
 const onlyOneEnabled = computed(() => [ isPo_200mg_400mg_600mg_800mgEnabled.value, isPo_20mgml_40mgmlEnabled.value, isSupp_75mg_125mg_150mg_250mgEnabled.value, isIv_4mgml_6mgml_100mlEnabled.value ].filter(Boolean).length === 1)
 

--- a/src/views/content/medications/ibuprofen/Packages.ts
+++ b/src/views/content/medications/ibuprofen/Packages.ts
@@ -1,13 +1,23 @@
+import { useMedicationPackageFlags } from '@/composables/useMedicationPackageFlags'
+import { MedId } from '@/types/medication'
 import { resolvePackages } from '../resolvePackages'
 
-const packages = resolvePackages('ibuprofen', [
+const packageIds = [
   'po_200mg_400mg_600mg_800mg',
   'po_20mgml_40mgml',
   'supp_75mg_125mg_150mg_250mg',
   'iv_4mgml_6mgml_100ml'
-] as const)
+] as const
+
+const packages = resolvePackages('ibuprofen', packageIds)
+const packageFlags = useMedicationPackageFlags(MedId.Ibuprofen, packageIds)
 
 export const po_200mg_400mg_600mg_800mg = packages.po_200mg_400mg_600mg_800mg
 export const po_20mgml_40mgml = packages.po_20mgml_40mgml
 export const supp_75mg_125mg_150mg_250mg = packages.supp_75mg_125mg_150mg_250mg
 export const iv_4mgml_6mgml_100ml = packages.iv_4mgml_6mgml_100ml
+
+export const isPo_200mg_400mg_600mg_800mgEnabled = packageFlags.po_200mg_400mg_600mg_800mg
+export const isPo_20mgml_40mgmlEnabled = packageFlags.po_20mgml_40mgml
+export const isSupp_75mg_125mg_150mg_250mgEnabled = packageFlags.supp_75mg_125mg_150mg_250mg
+export const isIv_4mgml_6mgml_100mlEnabled = packageFlags.iv_4mgml_6mgml_100ml

--- a/src/views/content/medications/ipratropiumbromid/ContentIpratropiumbromid.vue
+++ b/src/views/content/medications/ipratropiumbromid/ContentIpratropiumbromid.vue
@@ -124,15 +124,9 @@ import TextMono from '@/components/TextMono.vue'
 import TextUnderline from '@/components/TextUnderline.vue'
 import TextColored from '@/components/TextColored.vue'
 
-import { inh_250ug, inh_500ug } from './Packages'
-import { MedId } from '@/types/medication'
-import { useConfigStore } from '@/stores/config'
-const configStore = useConfigStore()
+import { inh_250ug, inh_500ug, isInh_250ugEnabled, isInh_500ugEnabled } from './Packages'
 
 // ########################################################################################################
-
-const isInh_250ugEnabled = computed(() => configStore.checkPackageEnable(MedId.Ipratropiumbromid, inh_250ug.id))
-const isInh_500ugEnabled = computed(() => configStore.checkPackageEnable(MedId.Ipratropiumbromid, inh_500ug.id))
 
 const onlyOneEnabled = computed(() => [ isInh_250ugEnabled.value, isInh_500ugEnabled.value ].filter(Boolean).length === 1)
 

--- a/src/views/content/medications/ipratropiumbromid/Packages.ts
+++ b/src/views/content/medications/ipratropiumbromid/Packages.ts
@@ -1,9 +1,17 @@
+import { useMedicationPackageFlags } from '@/composables/useMedicationPackageFlags'
+import { MedId } from '@/types/medication'
 import { resolvePackages } from '../resolvePackages'
 
-const packages = resolvePackages('ipratropiumbromid', [
+const packageIds = [
   'inh_250ug',
   'inh_500ug'
-] as const)
+] as const
+
+const packages = resolvePackages('ipratropiumbromid', packageIds)
+const packageFlags = useMedicationPackageFlags(MedId.Ipratropiumbromid, packageIds)
 
 export const inh_250ug = packages.inh_250ug
 export const inh_500ug = packages.inh_500ug
+
+export const isInh_250ugEnabled = packageFlags.inh_250ug
+export const isInh_500ugEnabled = packageFlags.inh_500ug

--- a/src/views/content/medications/midazolam/ContentMidazolam.vue
+++ b/src/views/content/medications/midazolam/ContentMidazolam.vue
@@ -231,17 +231,18 @@ import TextMono from '@/components/TextMono.vue'
 import TextUnderline from '@/components/TextUnderline.vue'
 import TextColored from '@/components/TextColored.vue'
 
-import { iv_5mgml_1ml, iv_5mgml_3ml, iv_1mgml_5ml, buccal_2_5mg_5mg_7_5mg_10mg } from './Packages'
-import { MedId } from '@/types/medication'
-import { useConfigStore } from '@/stores/config'
-const configStore = useConfigStore()
+import {
+  iv_5mgml_1ml,
+  iv_5mgml_3ml,
+  iv_1mgml_5ml,
+  buccal_2_5mg_5mg_7_5mg_10mg,
+  isIv_5mgml_1mlEnabled,
+  isIv_5mgml_3mlEnabled,
+  isIv_1mgml_5mlEnabled,
+  isBuccal_2_5mg_5mg_7_5mg_10mgEnabled,
+} from './Packages'
 
 // ########################################################################################################
-
-const isIv_5mgml_1mlEnabled = computed(() => configStore.checkPackageEnable(MedId.Midazolam, iv_5mgml_1ml.id))
-const isIv_5mgml_3mlEnabled = computed(() => configStore.checkPackageEnable(MedId.Midazolam, iv_5mgml_3ml.id))
-const isIv_1mgml_5mlEnabled = computed(() => configStore.checkPackageEnable(MedId.Midazolam, iv_1mgml_5ml.id))
-const isBuccal_2_5mg_5mg_7_5mg_10mgEnabled = computed(() => configStore.checkPackageEnable(MedId.Midazolam, buccal_2_5mg_5mg_7_5mg_10mg.id))
 
 const onlyOneEnabled = computed(() => [ onlyOneIvEnabled.value, isBuccal_2_5mg_5mg_7_5mg_10mgEnabled.value ].filter(Boolean).length === 1)
 const onlyOneIvEnabled = computed(() => [ isIv_5mgml_1mlEnabled.value, isIv_5mgml_3mlEnabled.value, isIv_1mgml_5mlEnabled.value ].filter(Boolean).length === 1)

--- a/src/views/content/medications/midazolam/Packages.ts
+++ b/src/views/content/medications/midazolam/Packages.ts
@@ -1,13 +1,23 @@
+import { useMedicationPackageFlags } from '@/composables/useMedicationPackageFlags'
+import { MedId } from '@/types/medication'
 import { resolvePackages } from '../resolvePackages'
 
-const packages = resolvePackages('midazolam', [
+const packageIds = [
   'iv_5mgml_1ml',
   'iv_5mgml_3ml',
   'iv_1mgml_5ml',
   'buccal_2_5mg_5mg_7_5mg_10mg',
-] as const)
+] as const
+
+const packages = resolvePackages('midazolam', packageIds)
+const packageFlags = useMedicationPackageFlags(MedId.Midazolam, packageIds)
 
 export const iv_5mgml_1ml = packages.iv_5mgml_1ml
 export const iv_5mgml_3ml = packages.iv_5mgml_3ml
 export const iv_1mgml_5ml = packages.iv_1mgml_5ml
 export const buccal_2_5mg_5mg_7_5mg_10mg = packages.buccal_2_5mg_5mg_7_5mg_10mg
+
+export const isIv_5mgml_1mlEnabled = packageFlags.iv_5mgml_1ml
+export const isIv_5mgml_3mlEnabled = packageFlags.iv_5mgml_3ml
+export const isIv_1mgml_5mlEnabled = packageFlags.iv_1mgml_5ml
+export const isBuccal_2_5mg_5mg_7_5mg_10mgEnabled = packageFlags.buccal_2_5mg_5mg_7_5mg_10mg

--- a/src/views/content/medications/morphin/ContentMorphin.vue
+++ b/src/views/content/medications/morphin/ContentMorphin.vue
@@ -139,15 +139,9 @@ import TextMono from '@/components/TextMono.vue'
 import TextUnderline from '@/components/TextUnderline.vue'
 import TextColored from '@/components/TextColored.vue'
 
-import { iv_10mg, iv_20mg } from './Packages'
-import { MedId } from '@/types/medication'
-import { useConfigStore } from '@/stores/config'
-const configStore = useConfigStore()
+import { iv_10mg, iv_20mg, isIv_10mgEnabled, isIv_20mgEnabled } from './Packages'
 
 // ########################################################################################################
-
-const isIv_10mgEnabled = computed(() => configStore.checkPackageEnable(MedId.Morphin, iv_10mg.id))
-const isIv_20mgEnabled = computed(() => configStore.checkPackageEnable(MedId.Morphin, iv_20mg.id))
 
 const onlyOneEnabled = computed(() => [ isIv_10mgEnabled.value, isIv_20mgEnabled.value ].filter(Boolean).length === 1)
 

--- a/src/views/content/medications/morphin/Packages.ts
+++ b/src/views/content/medications/morphin/Packages.ts
@@ -1,9 +1,17 @@
+import { useMedicationPackageFlags } from '@/composables/useMedicationPackageFlags'
+import { MedId } from '@/types/medication'
 import { resolvePackages } from '../resolvePackages'
 
-const packages = resolvePackages('morphin', [
+const packageIds = [
   'iv_10mg',
   'iv_20mg'
-] as const)
+] as const
+
+const packages = resolvePackages('morphin', packageIds)
+const packageFlags = useMedicationPackageFlags(MedId.Morphin, packageIds)
 
 export const iv_10mg = packages.iv_10mg
 export const iv_20mg = packages.iv_20mg
+
+export const isIv_10mgEnabled = packageFlags.iv_10mg
+export const isIv_20mgEnabled = packageFlags.iv_20mg

--- a/src/views/content/medications/paracetamol/ContentParacetamol.vue
+++ b/src/views/content/medications/paracetamol/ContentParacetamol.vue
@@ -145,17 +145,18 @@ import TextMono from '@/components/TextMono.vue'
 import TextUnderline from '@/components/TextUnderline.vue'
 import TextColored from '@/components/TextColored.vue'
 
-import { po_500mg, po_40mgml, supp_125mg_250mg, iv_10mgml_100ml } from './Packages'
-import { MedId } from '@/types/medication'
-import { useConfigStore } from '@/stores/config'
-const configStore = useConfigStore()
+import {
+  po_500mg,
+  po_40mgml,
+  supp_125mg_250mg,
+  iv_10mgml_100ml,
+  isPo_500mgEnabled,
+  isPo_40mgmlEnabled,
+  isSupp_125mg_250mgEnabled,
+  isIv_10mgml_100mlEnabled,
+} from './Packages'
 
 // ########################################################################################################
-
-const isPo_500mgEnabled = computed(() => configStore.checkPackageEnable(MedId.Paracetamol, po_500mg.id))
-const isPo_40mgmlEnabled = computed(() => configStore.checkPackageEnable(MedId.Paracetamol, po_40mgml.id))
-const isSupp_125mg_250mgEnabled = computed(() => configStore.checkPackageEnable(MedId.Paracetamol, supp_125mg_250mg.id))
-const isIv_10mgml_100mlEnabled = computed(() => configStore.checkPackageEnable(MedId.Paracetamol, iv_10mgml_100ml.id))
 
 const onlyOneEnabled = computed(() => [ isPo_500mgEnabled.value, isPo_40mgmlEnabled.value, isSupp_125mg_250mgEnabled.value, isIv_10mgml_100mlEnabled.value ].filter(Boolean).length === 1)
 

--- a/src/views/content/medications/paracetamol/Packages.ts
+++ b/src/views/content/medications/paracetamol/Packages.ts
@@ -1,13 +1,23 @@
+import { useMedicationPackageFlags } from '@/composables/useMedicationPackageFlags'
+import { MedId } from '@/types/medication'
 import { resolvePackages } from '../resolvePackages'
 
-const packages = resolvePackages('paracetamol', [
+const packageIds = [
   'po_500mg',
   'po_40mgml',
   'supp_125mg_250mg',
   'iv_10mgml_100ml'
-] as const)
+] as const
+
+const packages = resolvePackages('paracetamol', packageIds)
+const packageFlags = useMedicationPackageFlags(MedId.Paracetamol, packageIds)
 
 export const po_500mg = packages.po_500mg
 export const po_40mgml = packages.po_40mgml
 export const supp_125mg_250mg = packages.supp_125mg_250mg
 export const iv_10mgml_100ml = packages.iv_10mgml_100ml
+
+export const isPo_500mgEnabled = packageFlags.po_500mg
+export const isPo_40mgmlEnabled = packageFlags.po_40mgml
+export const isSupp_125mg_250mgEnabled = packageFlags.supp_125mg_250mg
+export const isIv_10mgml_100mlEnabled = packageFlags.iv_10mgml_100ml

--- a/src/views/content/medications/prednisolon/ContentPrednisolon.vue
+++ b/src/views/content/medications/prednisolon/ContentPrednisolon.vue
@@ -115,16 +115,16 @@ import TextMono from '@/components/TextMono.vue'
 import TextUnderline from '@/components/TextUnderline.vue'
 import TextColored from '@/components/TextColored.vue'
 
-import { supp_100mg, iv_100mg, iv_250mg } from './Packages'
-import { MedId } from '@/types/medication'
-import { useConfigStore } from '@/stores/config'
-const configStore = useConfigStore()
+import {
+  supp_100mg,
+  iv_100mg,
+  iv_250mg,
+  isSupp_100mgEnabled,
+  isIv_100mgEnabled,
+  isIv_250mgEnabled,
+} from './Packages'
 
 // ########################################################################################################
-
-const isSupp_100mgEnabled = computed(() => configStore.checkPackageEnable(MedId.Prednisolon, supp_100mg.id))
-const isIv_100mgEnabled = computed(() => configStore.checkPackageEnable(MedId.Prednisolon, iv_100mg.id))
-const isIv_250mgEnabled = computed(() => configStore.checkPackageEnable(MedId.Prednisolon, iv_250mg.id))
 
 const onlyOneIvEnabled = computed(() => [ isIv_100mgEnabled.value, isIv_250mgEnabled.value ].filter(Boolean).length === 1)
 

--- a/src/views/content/medications/prednisolon/FragPrednisolonAnaphylaxieIv.vue
+++ b/src/views/content/medications/prednisolon/FragPrednisolonAnaphylaxieIv.vue
@@ -9,17 +9,14 @@
 
 <script setup lang="ts">
 
-import { iv_100mg, iv_250mg } from './Packages'
+import { isIv_100mgEnabled, isIv_250mgEnabled } from './Packages'
 import { MedId } from '@/types/medication'
 import { useConfigStore } from '@/stores/config'
-const configStore = useConfigStore()
 
 // ########################################################################################################
 
 const enabled = computed(() => useConfigStore()?.checkMedicationEnabled(MedId.Prednisolon) ?? true)
 
-const isIv_100mgEnabled = computed(() => configStore.checkPackageEnable(MedId.Prednisolon, iv_100mg.id))
-const isIv_250mgEnabled = computed(() => configStore.checkPackageEnable(MedId.Prednisolon, iv_250mg.id))
 const onlyOneIvEnabled = computed(() => [ isIv_100mgEnabled.value, isIv_250mgEnabled.value ].filter(Boolean).length === 1)
 
 // ########################################################################################################

--- a/src/views/content/medications/prednisolon/FragPrednisolonAnaphylaxieSupp.vue
+++ b/src/views/content/medications/prednisolon/FragPrednisolonAnaphylaxieSupp.vue
@@ -8,16 +8,13 @@
 
 <script setup lang="ts">
 
-import { supp_100mg } from './Packages'
+import { isSupp_100mgEnabled } from './Packages'
 import { MedId } from '@/types/medication'
 import { useConfigStore } from '@/stores/config'
-const configStore = useConfigStore()
 
 // ########################################################################################################
 
 const enabled = computed(() => useConfigStore()?.checkMedicationEnabled(MedId.Prednisolon) ?? true)
-const isSupp_100mgEnabled = computed(() => configStore.checkPackageEnable(MedId.Prednisolon, supp_100mg.id))
-
 // ########################################################################################################
 
 import { Patient } from '@/types/emergency';

--- a/src/views/content/medications/prednisolon/Packages.ts
+++ b/src/views/content/medications/prednisolon/Packages.ts
@@ -1,11 +1,20 @@
+import { useMedicationPackageFlags } from '@/composables/useMedicationPackageFlags'
+import { MedId } from '@/types/medication'
 import { resolvePackages } from '../resolvePackages'
 
-const packages = resolvePackages('prednisolon', [
+const packageIds = [
   'supp_100mg',
   'iv_100mg',
   'iv_250mg'
-] as const)
+] as const
+
+const packages = resolvePackages('prednisolon', packageIds)
+const packageFlags = useMedicationPackageFlags(MedId.Prednisolon, packageIds)
 
 export const supp_100mg = packages.supp_100mg
 export const iv_100mg = packages.iv_100mg
 export const iv_250mg = packages.iv_250mg
+
+export const isSupp_100mgEnabled = packageFlags.supp_100mg
+export const isIv_100mgEnabled = packageFlags.iv_100mg
+export const isIv_250mgEnabled = packageFlags.iv_250mg

--- a/src/views/content/medications/tranexam/ContentTranexam.vue
+++ b/src/views/content/medications/tranexam/ContentTranexam.vue
@@ -82,15 +82,9 @@ import TextMono from '@/components/TextMono.vue'
 import TextUnderline from '@/components/TextUnderline.vue'
 import TextColored from '@/components/TextColored.vue'
 
-import { iv_100mgml_5ml, iv_100mgml_10ml } from './Packages'
-import { MedId } from '@/types/medication'
-import { useConfigStore } from '@/stores/config'
-const configStore = useConfigStore()
+import { iv_100mgml_5ml, iv_100mgml_10ml, isIv_100mgml_5mlEnabled, isIv_100mgml_10mlEnabled } from './Packages'
 
 // ########################################################################################################
-
-const isIv_100mgml_5mlEnabled = computed(() => configStore.checkPackageEnable(MedId.Tranexam, iv_100mgml_5ml.id))
-const isIv_100mgml_10mlEnabled = computed(() => configStore.checkPackageEnable(MedId.Tranexam, iv_100mgml_10ml.id))
 
 </script>
 

--- a/src/views/content/medications/tranexam/Packages.ts
+++ b/src/views/content/medications/tranexam/Packages.ts
@@ -1,9 +1,17 @@
+import { useMedicationPackageFlags } from '@/composables/useMedicationPackageFlags'
+import { MedId } from '@/types/medication'
 import { resolvePackages } from '../resolvePackages'
 
-const packages = resolvePackages('tranexam', [
+const packageIds = [
   'iv_100mgml_5ml',
   'iv_100mgml_10ml'
-] as const)
+] as const
+
+const packages = resolvePackages('tranexam', packageIds)
+const packageFlags = useMedicationPackageFlags(MedId.Tranexam, packageIds)
 
 export const iv_100mgml_5ml = packages.iv_100mgml_5ml
 export const iv_100mgml_10ml = packages.iv_100mgml_10ml
+
+export const isIv_100mgml_5mlEnabled = packageFlags.iv_100mgml_5ml
+export const isIv_100mgml_10mlEnabled = packageFlags.iv_100mgml_10ml

--- a/src/views/content/medications/urapidil/ContentUrapidil.vue
+++ b/src/views/content/medications/urapidil/ContentUrapidil.vue
@@ -118,15 +118,9 @@ import TextMono from '@/components/TextMono.vue'
 import TextUnderline from '@/components/TextUnderline.vue'
 import TextColored from '@/components/TextColored.vue'
 
-import { iv_5mgml_5ml, iv_5mgml_10ml } from './Packages'
-import { MedId } from '@/types/medication'
-import { useConfigStore } from '@/stores/config'
-const configStore = useConfigStore()
+import { iv_5mgml_5ml, iv_5mgml_10ml, isIv_5mgml_5mlEnabled, isIv_5mgml_10mlEnabled } from './Packages'
 
 // ########################################################################################################
-
-const isIv_5mgml_5mlEnabled = computed(() => configStore.checkPackageEnable(MedId.Urapidil, iv_5mgml_5ml.id))
-const isIv_5mgml_10mlEnabled = computed(() => configStore.checkPackageEnable(MedId.Urapidil, iv_5mgml_10ml.id))
 
 </script>
 

--- a/src/views/content/medications/urapidil/Packages.ts
+++ b/src/views/content/medications/urapidil/Packages.ts
@@ -1,9 +1,17 @@
+import { useMedicationPackageFlags } from '@/composables/useMedicationPackageFlags'
+import { MedId } from '@/types/medication'
 import { resolvePackages } from '../resolvePackages'
 
-const packages = resolvePackages('urapidil', [
+const packageIds = [
   'iv_5mgml_5ml',
   'iv_5mgml_10ml'
-] as const)
+] as const
+
+const packages = resolvePackages('urapidil', packageIds)
+const packageFlags = useMedicationPackageFlags(MedId.Urapidil, packageIds)
 
 export const iv_5mgml_5ml = packages.iv_5mgml_5ml
 export const iv_5mgml_10ml = packages.iv_5mgml_10ml
+
+export const isIv_5mgml_5mlEnabled = packageFlags.iv_5mgml_5ml
+export const isIv_5mgml_10mlEnabled = packageFlags.iv_5mgml_10ml


### PR DESCRIPTION
## Summary
- add a `useMedicationPackageFlags` composable that returns typed computed enablement flags for medication packages
- update medication package modules to export the new computed flags via the composable
- adjust content and fragment components to consume the exported flags instead of defining local store checks

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e28acaaf28832e9c3e55ef05066e37