### PR TITLE
Improve pediatric age estimation from curves

### DIFF
--- a/src/types/emergency.ts
+++ b/src/types/emergency.ts
@@ -101,6 +101,9 @@ export class Patient {
   {
     if (!this.Height || this.Height <= 0) { return undefined }
 
+    const childAge = CurveCalculation.calculateChildAgeByHeight(this.Sex, this.Height)
+    if (childAge !== undefined) { return childAge }
+
     const height = this.Height
     if (this.Sex == 'male')
     {
@@ -126,6 +129,9 @@ export class Patient {
   private estimateAgeFromWeight(): number | undefined
   {
     if (!this.Weight || this.Weight <= 0) { return undefined }
+
+    const childAge = CurveCalculation.calculateChildAgeByWeight(this.Sex, this.Weight)
+    if (childAge !== undefined) { return childAge }
 
     const weight = this.Weight
     if (weight < 20) { return 5 }


### PR DESCRIPTION
## Summary
- add curve utilities that infer child age from the growth curve by weight and height
- use the new helpers in emergency age estimation for more accurate pediatric results while keeping adult fallbacks

## Testing
- npm run lint *(fails: pre-existing lint violations throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b4656a04832e9076f3988aa3f1c3