### PR TITLE
Replace custom tags in ContentStandards with spans

### DIFF
--- a/src/views/content/emergency/standards/ContentStandards.vue
+++ b/src/views/content/emergency/standards/ContentStandards.vue
@@ -3,23 +3,23 @@
     <ns-key-value-container>
       <ns-key-value label="Puls">
         <p range>
-          <low><value>{{ normVitals.pulseLow }}</value>/<unit>min</unit></low>
-          <norm><value>{{ normVitals.pulse }}</value>/<unit>min</unit></norm>
-          <high><value>{{ normVitals.pulseHigh }}</value>/<unit>min</unit></high>
+          <span class="range-level range-level--low"><value>{{ normVitals.pulseLow }}</value>/<unit>min</unit></span>
+          <span class="range-level range-level--norm"><value>{{ normVitals.pulse }}</value>/<unit>min</unit></span>
+          <span class="range-level range-level--high"><value>{{ normVitals.pulseHigh }}</value>/<unit>min</unit></span>
         </p>
       </ns-key-value>
       <ns-key-value label="Blutdruck">
         <p range>
-          <low><value>{{ normVitals.pressureLow }}</value><sub>syst</sub></low>
-          <norm><value>{{ normVitals.pressure }}</value><unit><sub>syst</sub></unit></norm>
-          <high><value>{{ normVitals.pressureHigh }}</value><sub>syst</sub></high>
+          <span class="range-level range-level--low"><value>{{ normVitals.pressureLow }}</value><sub>syst</sub></span>
+          <span class="range-level range-level--norm"><value>{{ normVitals.pressure }}</value><unit><sub>syst</sub></unit></span>
+          <span class="range-level range-level--high"><value>{{ normVitals.pressureHigh }}</value><sub>syst</sub></span>
         </p>
       </ns-key-value>
       <ns-key-value label="AF">
         <p range>
-          <low><value>{{ normVitals.respirationLow }}</value>/<unit>min</unit></low>
-          <norm><value>{{ normVitals.respiration }}</value>/<unit>min</unit></norm>
-          <high><value>{{ normVitals.respirationHigh }}</value>/<unit>min</unit></high>
+          <span class="range-level range-level--low"><value>{{ normVitals.respirationLow }}</value>/<unit>min</unit></span>
+          <span class="range-level range-level--norm"><value>{{ normVitals.respiration }}</value>/<unit>min</unit></span>
+          <span class="range-level range-level--high"><value>{{ normVitals.respirationHigh }}</value>/<unit>min</unit></span>
         </p>
       </ns-key-value>
     </ns-key-value-container>
@@ -150,19 +150,22 @@ p[range] unit {
   font-weight: 100;
 }
 
-p[range] low,
-p[range] high {
-  color: var(--ns-color-blue);
+p[range] .range-level {
   letter-spacing: 0px;
+}
+
+p[range] .range-level--low,
+p[range] .range-level--high {
+  color: var(--ns-color-blue);
   font-size: 0.9em;
 }
-p[range] high {
+p[range] .range-level--high {
   color: var(--ns-color-red);
 }
-p[range] low::after {
+p[range] .range-level--low::after {
   content: ' >';
 }
-p[range] high::before {
+p[range] .range-level--high::before {
   content: '< ';
 }
 


### PR DESCRIPTION
## Summary
- replace the non-standard `low`, `norm`, and `high` tags in ContentStandards with span elements
- update the associated styling selectors to target the new class-based structure

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e37d214c58832ebccf12a22caa8f1e