### PR TITLE
Emergency Cards no gap between elements

### DIFF
--- a/src/components/NsContentGroup.vue
+++ b/src/components/NsContentGroup.vue
@@ -34,7 +34,8 @@ defineProps<{
 .ns-content-group.no-header {
   padding-top: var(--ns-card-padding);
 }
-.ns-content-group.no-header ion-card-content {
+.ns-content-group.no-header ion-card-content,
+.ns-content-group.dense-header ion-card-content {
   display: flex;
   flex-direction: column;
   gap: .5rem;


### PR DESCRIPTION
Fixes #93

always use flex+gap if there is a dense/missing header